### PR TITLE
fix(sys): use npx for bun and remove dups in husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,2 @@
 npx --no -- commitlint --edit $1
+

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
-bun lint
-bun prettier:check
+npm run lint
+

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,2 @@
-forge test
+npm test
+

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   "scripts": {
     "clean": "rm -rf cache out",
     "build": "forge build",
-    "lint": "bun run lint:sol && bun lint:md && bun run prettier:check",
-    "lint:sol": "forge fmt --check && bun solhint {script,src,test}/**/*.sol",
-    "lint:md": "bun markdownlint-cli2 .",
+    "lint": "npx bun run lint:sol && npx bun lint:md && npx bun run prettier:check",
+    "lint:sol": "forge fmt --check && npx bun solhint {script,src,test}/**/*.sol",
+    "lint:md": "npx bun markdownlint-cli2 .",
     "prettier:check": "prettier --check \"**/*.{json,md,yml}\" --ignore-path \".prettierignore\"",
     "prettier:write": "prettier --write \"**/*.{json,md,yml}\" --ignore-path \".prettierignore\"",
     "test": "forge test",


### PR DESCRIPTION
## What

- adds npx before bun calls so that it doesn't fail on systems without bun global installation
- uses npm calls to in husky to call those bun jobs
- removes prettier call in husky as already called by npm lint

## Why

- smoothen dev experience and not everyone will want to install global packages

## Testing

- uninstall bun (if installed)
- make commit and see if all linter and prettier tests are run

## Refs

none
