### PR TITLE
refactor(dependencies): implement soldeer as package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ node_modules
 # solidity-coverage files
 /coverage
 /coverage.json
+
+# soldeer dependencies
+/dependencies

--- a/README.md
+++ b/README.md
@@ -100,6 +100,27 @@ This is how to install dependencies:
 2. Add a remapping for the dependency in [remappings.txt](./remappings.txt), e.g.
    `dependency-name=node_modules/dependency-name`
 
+### Soldeer
+
+Install cargo
+
+```sh
+curl https://sh.rustup.rs -sSf | sh
+. "$HOME/.cargo/env"
+```
+
+Install soldeer
+
+```sh
+cargo install soldeer
+```
+
+Install dependencies
+
+```sh
+soldeer install
+```
+
 Note that OpenZeppelin Contracts is pre-installed, so you can follow that as an example.
 
 ## Writing Tests

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,6 +14,7 @@
   solc = "0.8.20"
   src = "src"
   test = "test"
+  libs = ["dependencies"]
 
 [profile.ci]
   fuzz = { runs = 10_000 }
@@ -33,3 +34,7 @@
 
 [rpc_endpoints]
   localhost = "http://localhost:8545"
+
+[dependencies]
+"@openzeppelin-contracts" = "5.0.2"
+forge-std = "1.9.1"

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,2 @@
-@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
-forge-std/=node_modules/forge-std/
+@openzeppelin-contracts-5.0.2=dependencies/@openzeppelin-contracts-5.0.2
+@forge-std-1.9.1=dependencies/forge-std-1.9.1

--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import { Script } from "forge-std/src/Script.sol";
+import { Script } from "@forge-std-1.9.1/src/Script.sol";
 
 abstract contract BaseScript is Script {
     /// @dev Included to enable compilation of the script without a $MNEMONIC environment variable.

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -1,0 +1,12 @@
+
+[[dependencies]]
+name = "@openzeppelin-contracts"
+version = "5.0.2"
+source = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/5_0_2_14-03-2024_06:11:59_contracts.zip"
+checksum = "8bc4f0acc7c187771b878d46f7de4bfad1acad2eb5d096d9d05d34035853f5c3"
+
+[[dependencies]]
+name = "forge-std"
+version = "1.9.1"
+source = "https://soldeer-revisions.s3.amazonaws.com/forge-std/v1_9_1_03-07-2024_14:44:59_forge-std-v1.9.1.zip"
+checksum = "110b35ad3604d91a919c521c71206c18cd07b29c750bd90b5cbbaf37288c9636"

--- a/src/BuilderRegistry.sol
+++ b/src/BuilderRegistry.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.20;
 
 import { Governed } from "./governance/Governed.sol";
-import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Ownable2Step } from "@openzeppelin-contracts-5.0.2/access/Ownable2Step.sol";
+import { Ownable } from "@openzeppelin-contracts-5.0.2/access/Ownable.sol";
 
 /**
  * @title BuilderRegistry

--- a/src/RewardDistributor.sol
+++ b/src/RewardDistributor.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin-contracts-5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin-contracts-5.0.2/token/ERC20/utils/SafeERC20.sol";
 import { SponsorsManager } from "./SponsorsManager.sol";
 import { EpochLib } from "./libraries/EpochLib.sol";
 

--- a/src/SponsorsManager.sol
+++ b/src/SponsorsManager.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { IERC20 } from "@openzeppelin-contracts-5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin-contracts-5.0.2/token/ERC20/utils/SafeERC20.sol";
+import { Math } from "@openzeppelin-contracts-5.0.2/utils/math/Math.sol";
 import { GaugeFactory } from "./gauge/GaugeFactory.sol";
 import { Gauge } from "./gauge/Gauge.sol";
 import { Governed } from "./governance/Governed.sol";

--- a/src/gauge/Gauge.sol
+++ b/src/gauge/Gauge.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
-import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Math } from "@openzeppelin-contracts-5.0.2/utils/math/Math.sol";
+import { IERC20 } from "@openzeppelin-contracts-5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin-contracts-5.0.2/token/ERC20/utils/SafeERC20.sol";
 import { UtilsLib } from "../libraries/UtilsLib.sol";
 import { EpochLib } from "../libraries/EpochLib.sol";
 

--- a/src/governance/ChangeExecutor.sol
+++ b/src/governance/ChangeExecutor.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
-import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import { ReentrancyGuard } from "@openzeppelin-contracts-5.0.2/utils/ReentrancyGuard.sol";
 import { IChangeContract } from "../interfaces/IChangeContract.sol";
 
 /**

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
-import { Test } from "forge-std/src/Test.sol";
+import { Test } from "@forge-std-1.9.1/src/Test.sol";
 import { ChangeExecutorMock } from "./mock/ChangeExecutorMock.sol";
 import { ERC20Mock } from "./mock/ERC20Mock.sol";
 import { GaugeFactory } from "../src/gauge/GaugeFactory.sol";

--- a/test/BuilderRegistry.t.sol
+++ b/test/BuilderRegistry.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
-import { stdStorage, StdStorage } from "forge-std/src/Test.sol";
+import { stdStorage, StdStorage } from "@forge-std-1.9.1/src/Test.sol";
 import { BaseTest, BuilderRegistry } from "./BaseTest.sol";
 import { Governed } from "../src/governance/Governed.sol";
 

--- a/test/RewardDistributor.t.sol
+++ b/test/RewardDistributor.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
-import { stdError } from "forge-std/src/Test.sol";
+import { stdError } from "@forge-std-1.9.1/src/Test.sol";
 import { BaseTest, RewardDistributor } from "./BaseTest.sol";
 import { EpochLib } from "../src/libraries/EpochLib.sol";
-import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import { IERC20Errors } from "@openzeppelin-contracts-5.0.2/interfaces/draft-IERC6093.sol";
 
 contract RewardDistributorTest is BaseTest {
     function _setUp() internal override {

--- a/test/SponsorsManager.t.sol
+++ b/test/SponsorsManager.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
-import { stdError } from "forge-std/src/Test.sol";
+import { stdError } from "@forge-std-1.9.1/src/Test.sol";
 import { BaseTest, SponsorsManager, Gauge } from "./BaseTest.sol";
 import { EpochLib } from "../src/libraries/EpochLib.sol";
 

--- a/test/governance/Protected.t.sol
+++ b/test/governance/Protected.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
-import { stdError } from "forge-std/src/Test.sol";
+import { stdError } from "@forge-std-1.9.1/src/Test.sol";
 import { BaseTest, Gauge } from "../BaseTest.sol";
 import { Governed } from "../../src/governance/Governed.sol";
 

--- a/test/governance/changers/WhitelistBuilderChanger.t.sol
+++ b/test/governance/changers/WhitelistBuilderChanger.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
-import { stdError } from "forge-std/src/Test.sol";
+import { stdError } from "@forge-std-1.9.1/src/Test.sol";
 import { BaseTest, Gauge } from "../../BaseTest.sol";
 import { Governed } from "../../../src/governance/Governed.sol";
 import { ChangeExecutor } from "../../../src/governance/ChangeExecutor.sol";

--- a/test/mock/ERC20Mock.sol
+++ b/test/mock/ERC20Mock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC20 } from "@openzeppelin-contracts-5.0.2/token/ERC20/ERC20.sol";
 
 contract ERC20Mock is ERC20 {
     constructor() ERC20("ERC20Mock", "E20M") { }


### PR DESCRIPTION
## What

- Implement [soldeer](https://book.getfoundry.sh/projects/soldeer) as package manager

## Why

- We need to install foundry dependencies. For example [OZ library](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades) to manage upgradeable contracts

## Testing

- `soldeer install`
