### PR TITLE
TOK-175: account gauges rewards on a time base

### DIFF
--- a/test/Gauge.t.sol
+++ b/test/Gauge.t.sol
@@ -59,6 +59,10 @@ contract GaugeTest is BaseTest {
     function test_Allocate() public {
         // GIVEN a SponsorsManager contract
         vm.startPrank(address(sponsorsManager));
+        // AND a new epoch
+        _skipAndStartNewEpoch();
+        // AND half epoch pass
+        _skipRemainingEpochFraction(2);
 
         // WHEN allocates 1 ether to alice
         //  THEN Allocated event is emitted
@@ -72,6 +76,8 @@ contract GaugeTest is BaseTest {
         assertEq(gauge.totalAllocation(), 1 ether);
         // THEN rewardPerTokenStored is 0 because there is not rewards distributed
         assertEq(gauge.rewardPerTokenStored(), 0);
+        // THEN rewardShares is 302400 ether = 1 * 1/2 WEEK
+        assertEq(gauge.rewardShares(), 302_400 ether);
         // THEN rewardPerToken is 0 because there is not rewards distributed
         assertEq(gauge.rewardPerToken(), 0);
         // THEN alice reward is 0 because there is not rewards distributed
@@ -88,10 +94,14 @@ contract GaugeTest is BaseTest {
     function test_Deallocate() public {
         // GIVEN a SponsorsManager contract
         vm.startPrank(address(sponsorsManager));
+        // AND a new epoch
+        _skipAndStartNewEpoch();
         // AND 1 ether allocated to alice
         gauge.allocate(alice, 1 ether);
 
-        // WHEN deallocates all
+        // WHEN half epoch pass
+        _skipRemainingEpochFraction(2);
+        // AND deallocates all
         //  THEN Allocated event is emitted
         vm.expectEmit();
         emit NewAllocation(alice, 0 ether);
@@ -101,6 +111,8 @@ contract GaugeTest is BaseTest {
         assertEq(gauge.allocationOf(alice), 0);
         // THEN totalAllocation is 0
         assertEq(gauge.totalAllocation(), 0);
+        // THEN rewardShares is 302400 ether = 1 * 1/2 WEEK
+        assertEq(gauge.rewardShares(), 302_400 ether);
         // THEN rewardPerTokenStored is 0 because there is not rewards distributed
         assertEq(gauge.rewardPerTokenStored(), 0);
         // THEN rewardPerToken is 0 because there is not rewards distributed
@@ -119,16 +131,22 @@ contract GaugeTest is BaseTest {
     function test_DeallocatePartial() public {
         // GIVEN a SponsorsManager contract
         vm.startPrank(address(sponsorsManager));
+        // AND a new epoch
+        _skipAndStartNewEpoch();
         // AND 1 ether allocated to alice
         gauge.allocate(alice, 1 ether);
 
-        // WHEN deallocates 0.25 ether
+        // WHEN half epoch pass
+        _skipRemainingEpochFraction(2);
+        // AND deallocates 0.25 ether
         gauge.allocate(alice, 0.75 ether);
 
         // THEN alice allocation is 0.75 ether
         assertEq(gauge.allocationOf(alice), 0.75 ether);
         // THEN totalAllocation is 0.75 ether
         assertEq(gauge.totalAllocation(), 0.75 ether);
+        // THEN rewardShares is 529200 ether = 1 * 1/2 WEEK + 0.75 * 1/2 WEEK
+        assertEq(gauge.rewardShares(), 529_200 ether);
     }
 
     /**
@@ -215,6 +233,8 @@ contract GaugeTest is BaseTest {
         assertEq(gauge.periodFinish() - block.timestamp, 518_400);
         // THEN rewardRate is 0.000192901234567901 = 100 ether / 518400 sec
         assertEq(gauge.rewardRate() / 10 ** 18, 192_901_234_567_901);
+        // THEN rewardShares is 3628800 ether = 6 * 1 WEEK
+        assertEq(gauge.rewardShares(), 3_628_800 ether);
 
         // AND half epoch pass
         _skipRemainingEpochFraction(2);

--- a/test/SponsorsManager.t.sol
+++ b/test/SponsorsManager.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
-import { stdError } from "forge-std/src/Test.sol";
 import { BaseTest, SponsorsManager, Gauge } from "./BaseTest.sol";
 
 contract SponsorsManagerTest is BaseTest {
@@ -11,7 +10,9 @@ contract SponsorsManagerTest is BaseTest {
     event GaugeCreated(address indexed builder_, address indexed gauge_, address creator_);
     event NewAllocation(address indexed sponsor_, address indexed gauge_, uint256 allocation_);
     event NotifyReward(address indexed sender_, uint256 amount_);
-    event DistributeReward(address indexed sender_, address indexed gauge_, uint256 amount_);
+    event RewardDistributionStarted(address indexed sender_);
+    event RewardDistributed(address indexed sender_);
+    event RewardDistributionFinished(address indexed sender_);
 
     function _setUp() internal override {
         // mint some rewardTokens to this contract for reward distribution
@@ -65,6 +66,8 @@ contract SponsorsManagerTest is BaseTest {
     function test_AllocateBatch() public {
         // GIVEN a SponsorManager contract
         vm.startPrank(alice);
+        // AND a new epoch
+        _skipAndStartNewEpoch();
         allocationsArray[0] = 2 ether;
         allocationsArray[1] = 6 ether;
         // WHEN alice allocates 2 ether to builder and 6 ether to builder2
@@ -81,8 +84,8 @@ contract SponsorsManagerTest is BaseTest {
         allocationsArray[1] = 10 ether;
         sponsorsManager.allocateBatch(gaugesArray, allocationsArray);
 
-        // THEN total allocation is 22 ether
-        assertEq(sponsorsManager.totalAllocation(), 22 ether);
+        // THEN total potential rewards is 13305600 ether = 22 * 1 WEEK
+        assertEq(sponsorsManager.totalPotentialReward(), 13_305_600 ether);
         // THEN alice total allocation is 8 ether
         assertEq(sponsorsManager.sponsorTotalAllocation(alice), 8 ether);
         // THEN bob total allocation is 14 ether
@@ -95,22 +98,26 @@ contract SponsorsManagerTest is BaseTest {
     function test_ModifyAllocation() public {
         // GIVEN a SponsorManager contract
         vm.startPrank(alice);
+        // AND a new epoch
+        _skipAndStartNewEpoch();
         allocationsArray[0] = 2 ether;
         allocationsArray[1] = 6 ether;
         // WHEN alice allocates 2 ether to builder and 6 ether to builder2
         sponsorsManager.allocateBatch(gaugesArray, allocationsArray);
-        // THEN total allocation is 8 ether
-        assertEq(sponsorsManager.totalAllocation(), 8 ether);
+        // THEN total allocation is 4838400 ether = 8 * 1 WEEK
+        assertEq(sponsorsManager.totalPotentialReward(), 4_838_400 ether);
         // THEN alice total allocation is 8 ether
         assertEq(sponsorsManager.sponsorTotalAllocation(alice), 8 ether);
 
-        // WHEN alice modifies the allocation: 10 ether to builder and 0 ether to builder2
+        // WHEN half epoch pass
+        _skipRemainingEpochFraction(2);
+        // AND alice modifies the allocation: 10 ether to builder and 0 ether to builder2
         allocationsArray[0] = 10 ether;
         allocationsArray[1] = 0 ether;
         sponsorsManager.allocateBatch(gaugesArray, allocationsArray);
 
-        // THEN total allocation is 10 ether
-        assertEq(sponsorsManager.totalAllocation(), 10 ether);
+        // THEN total allocation is 5443200 ether = 8 * 1 WEEK + 2 * 1/2 WEEK
+        assertEq(sponsorsManager.totalPotentialReward(), 5_443_200 ether);
         // THEN alice total allocation is 10 ether
         assertEq(sponsorsManager.sponsorTotalAllocation(alice), 10 ether);
     }
@@ -135,17 +142,6 @@ contract SponsorsManagerTest is BaseTest {
     }
 
     /**
-     * SCENARIO: notifyRewardAmount is called without any allocation
-     */
-    function test_NotifyRewardAmountWithoutAllocation() public {
-        // GIVEN a SponsorManager contract
-        //  WHEN notifyRewardAmount is called without allocations
-        //   THEN tx reverts because division by zero
-        vm.expectRevert(stdError.divisionError);
-        sponsorsManager.notifyRewardAmount(2 ether);
-    }
-
-    /**
      * SCENARIO: notifyRewardAmount is called and values are updated
      */
     function test_NotifyRewardAmount() public {
@@ -158,8 +154,8 @@ contract SponsorsManagerTest is BaseTest {
         vm.expectEmit();
         emit NotifyReward(address(this), 2 ether);
         sponsorsManager.notifyRewardAmount(2 ether);
-        // THEN rewardsPerShare is 20 = 2 / 0.1 ether
-        assertEq(sponsorsManager.rewardsPerShare(), 20 ether);
+        // THEN rewards is 2 ether
+        assertEq(sponsorsManager.rewards(), 2 ether);
         // THEN reward token balance of sponsorsManager is 2 ether
         assertEq(rewardToken.balanceOf(address(sponsorsManager)), 2 ether);
     }
@@ -176,8 +172,8 @@ contract SponsorsManagerTest is BaseTest {
         sponsorsManager.notifyRewardAmount(2 ether);
         // WHEN 10 ether reward are more added
         sponsorsManager.notifyRewardAmount(10 ether);
-        // THEN rewardsPerShare is 120 = 12 / 0.1 ether
-        assertEq(sponsorsManager.rewardsPerShare(), 120 ether);
+        // THEN rewardsPerShare is 12 ether
+        assertEq(sponsorsManager.rewards(), 12 ether);
         // THEN reward token balance of sponsorsManager is 12 ether
         assertEq(rewardToken.balanceOf(address(sponsorsManager)), 12 ether);
     }
@@ -265,17 +261,20 @@ contract SponsorsManagerTest is BaseTest {
         _skipToStartDistributionWindow();
 
         //  WHEN distribute is executed
-        //   THEN DistributeReward event is emitted for gauge
+        //   THEN RewardDistributionStarted event is emitted
         vm.expectEmit();
-        emit DistributeReward(address(this), address(gauge), 27_272_727_272_727_272_724);
-        //   THEN DistributeReward event is emitted for gauge2
+        emit RewardDistributionStarted(address(this));
+        //   THEN RewardDistributed event is emitted
         vm.expectEmit();
-        emit DistributeReward(address(this), address(gauge2), 72_727_272_727_272_727_264);
+        emit RewardDistributed(address(this));
+        //   THEN RewardDistributionFinished event is emitted
+        vm.expectEmit();
+        emit RewardDistributionFinished(address(this));
         sponsorsManager.startDistribution();
-        // THEN reward token balance of gauge is 27.272727272727272724 = 100 * 6 / 22
-        assertEq(rewardToken.balanceOf(address(gauge)), 27_272_727_272_727_272_724);
-        // THEN reward token balance of gauge2 is 72.727272727272727264 = 100 * 16 / 22
-        assertEq(rewardToken.balanceOf(address(gauge2)), 72_727_272_727_272_727_264);
+        // THEN reward token balance of gauge is 27.272727272727272727 = 100 * 6 / 22
+        assertEq(rewardToken.balanceOf(address(gauge)), 27_272_727_272_727_272_727);
+        // THEN reward token balance of gauge2 is 72.727272727272727272 = 100 * 16 / 22
+        assertEq(rewardToken.balanceOf(address(gauge2)), 72_727_272_727_272_727_272);
     }
 
     /**
@@ -315,10 +314,211 @@ contract SponsorsManagerTest is BaseTest {
         sponsorsManager.notifyRewardAmount(100 ether);
         sponsorsManager.startDistribution();
 
-        // THEN reward token balance of gauge is 91.558441558441558428 = 100 * 6 / 22 + 100 * 18 / 28
-        assertEq(rewardToken.balanceOf(address(gauge)), 91_558_441_558_441_558_428);
-        // THEN reward token balance of gauge2 is 108.441558441558441544 = 100 * 16 / 22 + 100 * 10 / 28
-        assertEq(rewardToken.balanceOf(address(gauge2)), 108_441_558_441_558_441_544);
+        // THEN reward token balance of gauge is 91.558441558441558441 = 100 * 6 / 22 + 100 * 18 / 28
+        assertEq(rewardToken.balanceOf(address(gauge)), 91_558_441_558_441_558_441);
+        // THEN reward token balance of gauge2 is 108.441558441558441557 = 100 * 16 / 22 + 100 * 10 / 28
+        assertEq(rewardToken.balanceOf(address(gauge2)), 108_441_558_441_558_441_557);
+    }
+
+    /**
+     * SCENARIO: alice transfer part of her allocation in the middle of the epoch
+     *  from builder to builder2, so the rewards accounted on that time are moved to builder2 too
+     */
+    function test_ModifyAllocationBeforeDistribution() public {
+        // GIVEN a SponsorManager contract
+        // AND a new epoch
+        _skipAndStartNewEpoch();
+        // AND alice allocates 10 ether to builder
+        vm.prank(alice);
+        sponsorsManager.allocate(gauge, 10 ether);
+
+        // AND bob allocates 10 ether to builder2
+        vm.prank(bob);
+        sponsorsManager.allocate(gauge2, 10 ether);
+
+        // AND half epoch pass
+        _skipRemainingEpochFraction(2);
+        // AND alice modifies his allocations 5 ether to builder2
+        vm.startPrank(alice);
+        sponsorsManager.allocate(gauge, 5 ether);
+        sponsorsManager.allocate(gauge2, 5 ether);
+        vm.stopPrank();
+
+        // THEN rewardShares is 4536000 ether = 10 * 1/2 WEEK + 5 * 1/2 WEEK
+        assertEq(gauge.rewardShares(), 4_536_000 ether);
+        // THEN rewardShares is 7560000 ether = 10 * 1/2 WEEK + 15 * 1/2 WEEK
+        assertEq(gauge2.rewardShares(), 7_560_000 ether);
+        // THEN total allocation is 12096000 ether = 4536000 + 7560000
+        assertEq(sponsorsManager.totalPotentialReward(), 12_096_000 ether);
+
+        //  AND 100 ether reward are added and distributed
+        sponsorsManager.notifyRewardAmount(100 ether);
+        // AND distribution window starts
+        _skipToStartDistributionWindow();
+        // AND distribution is executed
+        sponsorsManager.startDistribution();
+
+        // THEN rewardShares is 3024000 ether = 5 * 1 WEEK
+        assertEq(gauge.rewardShares(), 3_024_000 ether);
+        // THEN rewardShares is 9072000 ether = 15 * 1 WEEK
+        assertEq(gauge2.rewardShares(), 9_072_000 ether);
+        // THEN total allocation is 12096000 ether = 3024000 + 9072000
+        assertEq(sponsorsManager.totalPotentialReward(), 12_096_000 ether);
+
+        // THEN reward token balance of gauge is 37.5 ether = 100 * 4536000 / 12096000
+        assertEq(rewardToken.balanceOf(address(gauge)), 37.5 ether);
+        // THEN reward token balance of gauge2 is 62.5 ether = 100 * 7560000 / 12096000
+        assertEq(rewardToken.balanceOf(address(gauge2)), 62.5 ether);
+    }
+
+    /**
+     * SCENARIO: alice removes all her allocation in the middle of the epoch
+     *  from builder, so the rewards accounted on that time decrease
+     */
+    function test_UnallocationBeforeDistribution() public {
+        // GIVEN a SponsorManager contract
+        // AND a new epoch
+        _skipAndStartNewEpoch();
+        // AND alice allocates 10 ether to builder
+        vm.prank(alice);
+        sponsorsManager.allocate(gauge, 10 ether);
+
+        // AND bob allocates 10 ether to builder2
+        vm.prank(bob);
+        sponsorsManager.allocate(gauge2, 10 ether);
+
+        // AND half epoch pass
+        _skipRemainingEpochFraction(2);
+        // AND alice unallocates all from builder
+        vm.startPrank(alice);
+        sponsorsManager.allocate(gauge, 0);
+        vm.stopPrank();
+
+        // THEN rewardShares is 3024000 ether = 10 * 1/2 WEEK
+        assertEq(gauge.rewardShares(), 3_024_000 ether);
+        // THEN rewardShares is 6048000 ether = 10 * 1 WEEK
+        assertEq(gauge2.rewardShares(), 6_048_000 ether);
+        // THEN total allocation is 9072000 ether = 3024000 + 6048000
+        assertEq(sponsorsManager.totalPotentialReward(), 9_072_000 ether);
+
+        //  AND 100 ether reward are added and distributed
+        sponsorsManager.notifyRewardAmount(100 ether);
+        // AND distribution window starts
+        _skipToStartDistributionWindow();
+        // AND distribution is executed
+        sponsorsManager.startDistribution();
+
+        // THEN rewardShares is 0
+        assertEq(gauge.rewardShares(), 0);
+        // THEN rewardShares is 6048000 ether = 10 * 1 WEEK
+        assertEq(gauge2.rewardShares(), 6_048_000 ether);
+        // THEN total allocation is 6048000 ether = 0 + 6048000
+        assertEq(sponsorsManager.totalPotentialReward(), 6_048_000 ether);
+
+        // THEN reward token balance of gauge is 33.33 ether = 100 * 3024000 / 9072000
+        assertEq(rewardToken.balanceOf(address(gauge)), 33_333_333_333_333_333_333);
+        // THEN reward token balance of gauge2 is 66.66 ether = 100 * 6048000 / 9072000
+        assertEq(rewardToken.balanceOf(address(gauge2)), 66_666_666_666_666_666_666);
+    }
+
+    /**
+     * SCENARIO: alice removes part of her allocation in the middle of the epoch
+     *  from builder, so the rewards accounted on that time decrease
+     */
+    function test_RemoveAllocationBeforeDistribution() public {
+        // GIVEN a SponsorManager contract
+        // AND a new epoch
+        _skipAndStartNewEpoch();
+        // AND alice allocates 10 ether to builder
+        vm.prank(alice);
+        sponsorsManager.allocate(gauge, 10 ether);
+
+        // AND bob allocates 10 ether to builder2
+        vm.prank(bob);
+        sponsorsManager.allocate(gauge2, 10 ether);
+
+        // AND half epoch pass
+        _skipRemainingEpochFraction(2);
+        // AND alice removes 5 ether from builder
+        vm.startPrank(alice);
+        sponsorsManager.allocate(gauge, 5 ether);
+        vm.stopPrank();
+
+        // THEN rewardShares is 4536000 ether = 10 * 1/2 WEEK + 5 * 1/2 WEEK
+        assertEq(gauge.rewardShares(), 4_536_000 ether);
+        // THEN rewardShares is 6048000 ether = 10 * 1 WEEK
+        assertEq(gauge2.rewardShares(), 6_048_000 ether);
+        // THEN total allocation is 10584000 ether = 4536000 + 6048000
+        assertEq(sponsorsManager.totalPotentialReward(), 10_584_000 ether);
+
+        //  AND 100 ether reward are added and distributed
+        sponsorsManager.notifyRewardAmount(100 ether);
+        // AND distribution window starts
+        _skipToStartDistributionWindow();
+        // AND distribution is executed
+        sponsorsManager.startDistribution();
+
+        // THEN rewardShares is 3024000 ether = 5 * 1 WEEK
+        assertEq(gauge.rewardShares(), 3_024_000 ether);
+        // THEN rewardShares is 6048000 ether = 10 * 1 WEEK
+        assertEq(gauge2.rewardShares(), 6_048_000 ether);
+        // THEN total allocation is 9072000 ether = 3024000 + 6048000
+        assertEq(sponsorsManager.totalPotentialReward(), 9_072_000 ether);
+
+        // THEN reward token balance of gauge is 42.857 ether = 100 * 4536000 / 10584000
+        assertEq(rewardToken.balanceOf(address(gauge)), 42_857_142_857_142_857_142);
+        // THEN reward token balance of gauge2 is 57.142 ether = 100 * 6048000 / 10584000
+        assertEq(rewardToken.balanceOf(address(gauge2)), 57_142_857_142_857_142_857);
+    }
+
+    /**
+     * SCENARIO: alice adds allocation in the middle of the epoch
+     *  to builder, so the rewards accounted on that time increase
+     */
+    function test_AddAllocationBeforeDistribution() public {
+        // GIVEN a SponsorManager contract
+        // AND a new epoch
+        _skipAndStartNewEpoch();
+        // AND alice allocates 10 ether to builder
+        vm.prank(alice);
+        sponsorsManager.allocate(gauge, 10 ether);
+
+        // AND bob allocates 10 ether to builder2
+        vm.prank(bob);
+        sponsorsManager.allocate(gauge2, 10 ether);
+
+        // AND half epoch pass
+        _skipRemainingEpochFraction(2);
+        // AND alice adds 5 ether to builder
+        vm.startPrank(alice);
+        sponsorsManager.allocate(gauge, 15 ether);
+        vm.stopPrank();
+
+        // THEN rewardShares is 7560000 ether = 10 * 1/2 WEEK + 15 * 1/2 WEEK
+        assertEq(gauge.rewardShares(), 7_560_000 ether);
+        // THEN rewardShares is 6048000 ether = 10 * 1 WEEK
+        assertEq(gauge2.rewardShares(), 6_048_000 ether);
+        // THEN total allocation is 13608000 ether = 7560000 + 6048000
+        assertEq(sponsorsManager.totalPotentialReward(), 13_608_000 ether);
+
+        //  AND 100 ether reward are added and distributed
+        sponsorsManager.notifyRewardAmount(100 ether);
+        // AND distribution window starts
+        _skipToStartDistributionWindow();
+        // AND distribution is executed
+        sponsorsManager.startDistribution();
+
+        // THEN rewardShares is 9072000 ether = 15 * 1 WEEK
+        assertEq(gauge.rewardShares(), 9_072_000 ether);
+        // THEN rewardShares is 6048000 ether = 10 * 1 WEEK
+        assertEq(gauge2.rewardShares(), 6_048_000 ether);
+        // THEN total allocation is 15120000 ether = 9072000 + 6048000
+        assertEq(sponsorsManager.totalPotentialReward(), 15_120_000 ether);
+
+        // THEN reward token balance of gauge is 55.5 ether = 100 * 7560000 / 13608000
+        assertEq(rewardToken.balanceOf(address(gauge)), 55_555_555_555_555_555_555);
+        // THEN reward token balance of gauge2 is 44.4 ether = 100 * 6048000 / 13608000
+        assertEq(rewardToken.balanceOf(address(gauge2)), 44_444_444_444_444_444_444);
     }
 
     /**
@@ -360,10 +560,10 @@ contract SponsorsManagerTest is BaseTest {
         _skipToStartDistributionWindow();
         sponsorsManager.startDistribution();
 
-        // THEN reward token balance of gauge is 91.558441558441558428 = 100 * 6 / 22 + 100 * 18 / 28
-        assertEq(rewardToken.balanceOf(address(gauge)), 91_558_441_558_441_558_428);
-        // THEN reward token balance of gauge2 is 108.441558441558441544 = 100 * 16 / 22 + 100 * 10 / 28
-        assertEq(rewardToken.balanceOf(address(gauge2)), 108_441_558_441_558_441_544);
+        // THEN reward token balance of gauge is 91.558441558441558441 = 100 * 6 / 22 + 100 * 18 / 28
+        assertEq(rewardToken.balanceOf(address(gauge)), 91_558_441_558_441_558_441);
+        // THEN reward token balance of gauge2 is 108.441558441558441557 = 100 * 16 / 22 + 100 * 10 / 28
+        assertEq(rewardToken.balanceOf(address(gauge2)), 108_441_558_441_558_441_557);
     }
 
     /**


### PR DESCRIPTION
## What

- We want to  distribute rewards to Builder according to the time the votes are allocated. 

## Why

- To avoid users voting for a proposal during all the epoch but moving to another some blocks before the snapshot for the rewards distribution


Before
<img width="800" alt="image" src="https://github.com/user-attachments/assets/07a61436-2f10-4458-a312-14dfe7faba91">


After
<img width="794" alt="image" src="https://github.com/user-attachments/assets/5485b1c0-4620-48bc-80fd-fa28cd59783d">


- (optional: include links to other issues, PRs, tickets, etc)
