### PR TITLE
TOK-175: account gauges rewards on a time base

### DIFF
--- a/test/Gauge.t.sol
+++ b/test/Gauge.t.sol
@@ -168,22 +168,6 @@ contract GaugeTest is BaseTest {
     }
 
     /**
-     * SCENARIO: notifyRewardAmount should reverts if rewardRate is zero
-     */
-    function test_RevertZeroRewardRate() public {
-        // GIVEN a SponsorsManager contract
-        vm.startPrank(address(sponsorsManager));
-        // AND 1 ether allocated to alice and 5 ether to bob
-        gauge.allocate(alice, 1 ether);
-        gauge.allocate(bob, 5 ether);
-
-        // WHEN tries to distribute 0 ether and there is pending rewards
-        //  THEN tx reverts because ZeroRewardRate
-        vm.expectRevert(Gauge.ZeroRewardRate.selector);
-        gauge.notifyRewardAmount(0);
-    }
-
-    /**
      * SCENARIO: alice and bob claim his rewards at the end of the epoch receiving the total amount of rewards.
      *  If they claim again without a new reward distribution they don't receive rewardTokens again.
      */


### PR DESCRIPTION
## What

- We want to  distribute rewards to Builder according to the time the votes are allocated. 

## Why

- To avoid users voting for a proposal during all the epoch but moving to another some blocks before the snapshot for the rewards distribution


Before
<img width="800" alt="image" src="https://github.com/user-attachments/assets/07a61436-2f10-4458-a312-14dfe7faba91">


After
<img width="800" alt="image" src="https://github.com/user-attachments/assets/590ff22e-514e-4db5-8d0c-33219c3212b5">


- (optional: include links to other issues, PRs, tickets, etc)