### PR TITLE
TOK-173: Whitelist builder in changer template

### DIFF
--- a/src/SponsorsManager.sol
+++ b/src/SponsorsManager.sol
@@ -110,7 +110,7 @@ contract SponsorsManager is Governed {
      * @return gauge gauge contract
      */
     function createGauge(address builder_) external onlyGovernorOrAuthorizedChanger returns (Gauge gauge) {
-        // TODO: this function should revert if is not called by governance once the builder is whitelisted
+        // TODO: only if the builder is whitelisted?
         if (address(builderToGauge[builder_]) != address(0)) revert GaugeExists();
         gauge = gaugeFactory.createGauge(builder_, address(rewardToken));
         builderToGauge[builder_] = gauge;

--- a/src/governance/changerTemplates/WhitelistBuilderChangerTemplate.sol
+++ b/src/governance/changerTemplates/WhitelistBuilderChangerTemplate.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import { IChangeContract } from "../../interfaces/IChangeContract.sol";
 import { SponsorsManager } from "../../SponsorsManager.sol";
+import { BuilderRegistry } from "../../BuilderRegistry.sol";
 import { Gauge } from "../../gauge/Gauge.sol";
 
 /**
@@ -33,8 +34,7 @@ contract WhitelistBuilderChangerTemplate is IChangeContract {
      * because it is not its responsibility in the current architecture
      */
     function execute() external {
-        // TODO: whitelist the builder on the BuilderRegistry once
-        // https://rsklabs.atlassian.net/browse/TOK-117 is completed
+        sponsorsManager.builderRegistry().whitelistBuilder(builder);
         newGauge = sponsorsManager.createGauge(builder);
     }
 }


### PR DESCRIPTION
>[!IMPORTANT]
> Merge after #22 

## What

- We need to update the WhitelistBuilderChangerTemplate to make sure the BuilderRegitry is updated with the whitelisted builder

## Why

- On the same changer we are whitelisting the builder and creating its gauge

## Refs

- [TOK-173](https://rsklabs.atlassian.net/browse/TOK-173)
