### PR TITLE
fix(distribution): temporarily store totalPotentialReward in paginate…

### DIFF
--- a/src/SponsorsManager.sol
+++ b/src/SponsorsManager.sol
@@ -58,6 +58,8 @@ contract SponsorsManager is BuilderRegistry {
     IERC20 public rewardToken;
     /// @notice total potential reward
     uint256 public totalPotentialReward;
+    /// @notice on a paginated distribution we need to temporarily store the totalPotentialReward
+    uint256 public tempTotalPotentialReward;
     /// @notice rewards to distribute [PREC]
     uint256 public rewards;
     /// @notice index of tha last gauge distributed during a distribution period
@@ -177,7 +179,7 @@ contract SponsorsManager is BuilderRegistry {
     function distribute() public {
         if (onDistributionPeriod == false) revert DistributionPeriodDidNotStart();
         Gauge[] memory _gauges = gauges;
-        uint256 _newTotalPotentialReward;
+        uint256 _newTotalPotentialReward = tempTotalPotentialReward;
         uint256 _gaugeIndex = indexLastGaugeDistributed;
         uint256 _lastDistribution = Math.min(_gauges.length, _gaugeIndex + _MAX_DISTRIBUTIONS_PER_BATCH);
 
@@ -196,10 +198,12 @@ contract SponsorsManager is BuilderRegistry {
             indexLastGaugeDistributed = 0;
             onDistributionPeriod = false;
             rewards = 0;
+            tempTotalPotentialReward = 0;
             totalPotentialReward = _newTotalPotentialReward;
         } else {
             // Define new reference to batch beginning
             indexLastGaugeDistributed = _gaugeIndex;
+            tempTotalPotentialReward = _newTotalPotentialReward;
         }
     }
 

--- a/test/SponsorsManager.t.sol
+++ b/test/SponsorsManager.t.sol
@@ -561,6 +561,8 @@ contract SponsorsManagerTest is BaseTest {
 
         // WHEN distribute is executed
         sponsorsManager.startDistribution();
+        // THEN temporal total potential rewards is 12096000 ether = 20 * 1 WEEK
+        assertEq(sponsorsManager.tempTotalPotentialReward(), 12_096_000 ether);
         // THEN distribution period is still started
         assertEq(sponsorsManager.onDistributionPeriod(), true);
         // THEN last gauge distributed is gauge 20
@@ -568,6 +570,10 @@ contract SponsorsManagerTest is BaseTest {
 
         // AND distribute is executed again
         sponsorsManager.distribute();
+        // THEN temporal total potential rewards is 0
+        assertEq(sponsorsManager.tempTotalPotentialReward(), 0);
+        // THEN total potential rewards is 13305600 ether = 22 * 1 WEEK
+        assertEq(sponsorsManager.totalPotentialReward(), 13_305_600 ether);
         // THEN distribution period finished
         assertEq(sponsorsManager.onDistributionPeriod(), false);
         // THEN last gauge distributed is 0


### PR DESCRIPTION
## What

- On a paginated distribution we are losing all the previous totalPotentialReward calculated. We need to store the temporally

## Ref
https://github.com/rsksmart/builder-incentives-sc/pull/39#discussion_r1723694977
