### PR TITLE
fix(rewards): builders can only claim rewards on its gauge

### DIFF
--- a/src/gauge/Gauge.sol
+++ b/src/gauge/Gauge.sol
@@ -138,9 +138,10 @@ contract Gauge {
      * @dev reverts if is not called by the builder or reward receiver
      * @dev rewards are transferred to the builder reward receiver
      */
-    function claimBuilderReward(address builder_) external {
-        address _rewardReceiver = BuilderRegistry(sponsorsManager).builderRewardReceiver(builder_);
-        if (msg.sender != builder_ && msg.sender != _rewardReceiver) revert NotAuthorized();
+    function claimBuilderReward() external {
+        address _builder = BuilderRegistry(sponsorsManager).gaugeToBuilder(Gauge(address(this)));
+        address _rewardReceiver = BuilderRegistry(sponsorsManager).builderRewardReceiver(_builder);
+        if (msg.sender != _builder && msg.sender != _rewardReceiver) revert NotAuthorized();
 
         uint256 _reward = builderRewards;
         if (_reward > 0) {

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -37,6 +37,7 @@ contract BaseTest is Test {
     address internal bob = makeAddr("bob");
     address internal builder = makeAddr("builder");
     address internal builder2 = makeAddr("builder2");
+    address internal builder2Receiver = makeAddr("builder2Receiver");
     address internal kycApprover = makeAddr("kycApprover");
     address internal foundation = makeAddr("foundation");
     /* solhint-enable private-vars-leading-underscore */
@@ -56,8 +57,8 @@ contract BaseTest is Test {
         // allow to execute all the functions protected by governance
         changeExecutorMock.setIsAuthorized(true);
 
-        gauge = _whitelistBuilder(builder, builder, 1 ether);
-        gauge2 = _whitelistBuilder(builder2, builder2, 1 ether);
+        gauge = _whitelistBuilder(builder, builder, 0.5 ether);
+        gauge2 = _whitelistBuilder(builder2, builder2Receiver, 0.5 ether);
         gaugesArray = [gauge, gauge2];
 
         // mint some stakingTokens to alice and bob

--- a/test/SponsorsManager.t.sol
+++ b/test/SponsorsManager.t.sol
@@ -589,7 +589,7 @@ contract SponsorsManagerTest is BaseTest {
      * SCENARIO: alice claims all the rewards in a single tx
      */
     function test_ClaimSponsorRewards() public {
-        // GIVEN builder and builder2 which kickback percentage is 100%
+        // GIVEN builder and builder2 which kickback percentage is 50%
         //  AND a sponsor alice
         vm.startPrank(alice);
         allocationsArray[0] = 2 ether;
@@ -613,7 +613,7 @@ contract SponsorsManagerTest is BaseTest {
         vm.prank(alice);
         sponsorsManager.claimSponsorRewards(gaugesArray);
 
-        // THEN alice rewardToken balance is all of the distributed amount
-        assertEq(rewardToken.balanceOf(alice), 99_999_999_999_999_999_992);
+        // THEN alice rewardToken balance is 50% of the distributed amount
+        assertEq(rewardToken.balanceOf(alice), 49_999_999_999_999_999_992);
     }
 }


### PR DESCRIPTION
## What

- Builder can claim reward on any gauge stealing the rewards from the other builders

## Refs

- [TOK-220](https://rsklabs.atlassian.net/browse/TOK-220)