### PR TITLE
TOK-368: add canWithdraw function

### DIFF
--- a/script/test_mock/MockStakingToken.s.sol
+++ b/script/test_mock/MockStakingToken.s.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.20;
+
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { Broadcaster } from "script/script_utils/Broadcaster.s.sol";
+import { StakingTokenMock, DEFAULT_NAME, DEFAULT_SYMBOL } from "test/mock/StakingTokenMock.sol";
+
+contract Deploy is Broadcaster {
+    function run() public returns (StakingTokenMock) {
+        return run(vm.envOr("MOCK_TOKEN_COUNTER", uint256(0)));
+    }
+
+    function run(uint256 mockTokenCounter_) public broadcast returns (StakingTokenMock) {
+        string memory _name = DEFAULT_NAME;
+        string memory _symbol = DEFAULT_SYMBOL;
+
+        if (mockTokenCounter_ > 0) {
+            string memory _counterString = Strings.toString(mockTokenCounter_);
+            _name = string.concat(_name, "_", _counterString);
+            _symbol = string.concat(_symbol, "_", _counterString);
+        }
+
+        if (vm.envOr("NO_DD", false)) {
+            return new StakingTokenMock(_name, _symbol);
+        }
+        return new StakingTokenMock{ salt: _salt }(_name, _symbol);
+    }
+}

--- a/src/BuilderRegistry.sol
+++ b/src/BuilderRegistry.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import { EpochTimeKeeper } from "./EpochTimeKeeper.sol";
 import { UtilsLib } from "./libraries/UtilsLib.sol";
+import { ERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { Gauge } from "./gauge/Gauge.sol";
 import { GaugeFactory } from "./gauge/GaugeFactory.sol";
@@ -12,7 +13,7 @@ import { IGovernanceManager } from "./interfaces/IGovernanceManager.sol";
  * @title BuilderRegistry
  * @notice Keeps registers of the builders
  */
-abstract contract BuilderRegistry is EpochTimeKeeper {
+abstract contract BuilderRegistry is EpochTimeKeeper, ERC165Upgradeable {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     uint256 internal constant _MAX_KICKBACK = UtilsLib._PRECISION;
@@ -136,6 +137,7 @@ abstract contract BuilderRegistry is EpochTimeKeeper {
         onlyInitializing
     {
         __EpochTimeKeeper_init(governanceManager_, epochDuration_, epochStartOffset_);
+        __ERC165_init();
         gaugeFactory = GaugeFactory(gaugeFactory_);
         rewardDistributor = rewardDistributor_;
         kickbackCooldown = kickbackCooldown_;

--- a/src/interfaces/ICollectiveRewardsCheck.sol
+++ b/src/interfaces/ICollectiveRewardsCheck.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.20;
+
+/**
+ * @title ICollectiveRewardsCheck
+ *   @notice Used by stakingToken to validate if the staker can transfer its tokens
+ */
+interface ICollectiveRewardsCheck {
+    function canWithdraw(address targetAddress_, uint256 value_) external view returns (bool);
+}

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -3,11 +3,13 @@ pragma solidity 0.8.20;
 
 import { Test } from "forge-std/src/Test.sol";
 import { Deploy as MockTokenDeployer } from "script/test_mock/MockToken.s.sol";
+import { Deploy as MockStakingTokenDeployer } from "script/test_mock/MockStakingToken.s.sol";
 import { Deploy as GaugeBeaconDeployer } from "script/gauge/GaugeBeacon.s.sol";
 import { Deploy as GaugeFactoryDeployer } from "script/gauge/GaugeFactory.s.sol";
 import { Deploy as SponsorsManagerDeployer } from "script/SponsorsManager.s.sol";
 import { Deploy as RewardDistributorDeployer } from "script/RewardDistributor.s.sol";
 import { ERC20Mock } from "./mock/ERC20Mock.sol";
+import { StakingTokenMock } from "./mock/StakingTokenMock.sol";
 import { GaugeBeacon } from "src/gauge/GaugeBeacon.sol";
 import { GaugeFactory } from "src/gauge/GaugeFactory.sol";
 import { Gauge } from "src/gauge/Gauge.sol";
@@ -18,7 +20,7 @@ import { Deploy as GovernanceManagerDeployer } from "script/governance/Governanc
 import { GovernanceManager } from "src/governance/GovernanceManager.sol";
 
 contract BaseTest is Test {
-    ERC20Mock public stakingToken;
+    StakingTokenMock public stakingToken;
     ERC20Mock public rewardToken;
 
     GovernanceManager public governanceManager;
@@ -54,7 +56,8 @@ contract BaseTest is Test {
         (governanceManager,) = new GovernanceManagerDeployer().run(governor, foundation, kycApprover);
 
         MockTokenDeployer _mockTokenDeployer = new MockTokenDeployer();
-        stakingToken = _mockTokenDeployer.run(0);
+        MockStakingTokenDeployer _mockStakingTokenDeployer = new MockStakingTokenDeployer();
+        stakingToken = _mockStakingTokenDeployer.run(0);
         rewardToken = _mockTokenDeployer.run(1);
         gaugeBeacon = new GaugeBeaconDeployer().run(address(governanceManager));
         gaugeFactory = new GaugeFactoryDeployer().run(address(gaugeBeacon), address(rewardToken));

--- a/test/StakingTokenWithdrawability.t.sol
+++ b/test/StakingTokenWithdrawability.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.20;
+
+import { BaseTest, StakingTokenMock } from "./BaseTest.sol";
+
+contract StakingTokenWithdrawabilityTest is BaseTest {
+    function _setUp() internal override {
+        stakingToken.setCollectiveRewardsAddress(address(sponsorsManager));
+        // GIVEN alice and bob allocate to builder and builder2
+        //  AND 100 rewardToken and 10 coinbase are distributed
+        //   AND half epoch pass
+        _initialDistribution();
+
+        assertEq(stakingToken.balanceOf(alice), 100_000 ether);
+        assertEq(sponsorsManager.sponsorTotalAllocation(alice), 8 ether);
+        assertEq(stakingToken.balanceOf(bob), 100_000 ether);
+        assertEq(sponsorsManager.sponsorTotalAllocation(bob), 8 ether);
+    }
+
+    /**
+     * SCENARIO: canWithdraw should return true if staker has no allocations
+     */
+    function test_NoSponsorCanWithdrawAlwaysTrue() public view {
+        // GIVEN alice and bob have 100000 stakingToken and 8 allocated
+        //  THEN addresses with no allocation can withdraw anything
+        assertEq(sponsorsManager.canWithdraw(address(0), 1_000_000 ether), true);
+        assertEq(sponsorsManager.canWithdraw(address(1), 1_000_000 ether), true);
+    }
+
+    /**
+     * SCENARIO: canWithdraw should return true for values not allocated
+     */
+    function test_CanWithdrawNoAllocatedAmount() public view {
+        // GIVEN alice and bob have 100000 stakingToken and 8 allocated
+        // THEN alice can withdraw 99992
+        assertEq(sponsorsManager.canWithdraw(alice, 99_992 ether), true);
+        // THEN alice cannot withdraw 99993
+        assertEq(sponsorsManager.canWithdraw(alice, 99_993 ether), false);
+    }
+
+    /**
+     * SCENARIO: canWithdraw should return false is value is greater than the balance
+     */
+    function test_CanWithdrawNoEnoughBalance() public view {
+        // GIVEN alice and bob have 100000 stakingToken and 8 allocated
+        // THEN alice cannot withdraw 100001
+        assertEq(sponsorsManager.canWithdraw(alice, 100_001 ether), false);
+    }
+
+    /**
+     * SCENARIO: alice has 100000 stakingToken and 8 allocated, she can transfer 99992 tokens
+     */
+    function test_WithdrawAll() public {
+        // GIVEN alice and bob have 100000 stakingToken and 8 allocated
+        // WHEN alice transfers 99992 tokens to bob
+        vm.prank(alice);
+        stakingToken.transfer(bob, 99_992 ether);
+
+        // THEN alice stakingToken balance is 8
+        assertEq(stakingToken.balanceOf(alice), 8 ether);
+        // THEN bob stakingToken balance is 199_992
+        assertEq(stakingToken.balanceOf(bob), 199_992 ether);
+        // THEN alice allocation is still 8
+        assertEq(sponsorsManager.sponsorTotalAllocation(alice), 8 ether);
+        // THEN bob allocation is still 8
+        assertEq(sponsorsManager.sponsorTotalAllocation(bob), 8 ether);
+    }
+
+    /**
+     * SCENARIO: alice has 100000 stakingToken and 8 allocated, revert trying to transfer 99993 tokens
+     */
+    function test_RevertWithdraw() public {
+        // GIVEN alice and bob have 100000 stakingToken and 8 allocated
+        // WHEN alice transfers 99993 tokens to bob
+        //  THEN tx reverts because amount exceeds the tokens allocated
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(StakingTokenMock.STRIFStakedInCollectiveRewardsCanWithdraw.selector, false)
+        );
+        stakingToken.transfer(bob, 99_993 ether);
+    }
+}

--- a/test/invariant/handlers/AllocateHandler.sol
+++ b/test/invariant/handlers/AllocateHandler.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.20;
 
 import { BaseHandler, TimeManager } from "./BaseHandler.sol";
 import { BaseTest } from "../../BaseTest.sol";
-import { ERC20Mock } from "test/mock/ERC20Mock.sol";
+import { StakingTokenMock } from "../../mock/StakingTokenMock.sol";
 import { Gauge } from "src/gauge/Gauge.sol";
 
 contract AllocateHandler is BaseHandler {
-    ERC20Mock public stakingToken;
+    StakingTokenMock public stakingToken;
 
     address[] public sponsors;
     mapping(address sponsor => bool exists) public sponsorExists;

--- a/test/mock/StakingTokenMock.sol
+++ b/test/mock/StakingTokenMock.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.20;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import { ICollectiveRewardsCheck } from "../../src/interfaces/ICollectiveRewardsCheck.sol";
+
+string constant DEFAULT_NAME = "ERC20Mock";
+string constant DEFAULT_SYMBOL = "E20M";
+
+contract StakingTokenMock is ERC20 {
+    using ERC165Checker for address;
+
+    error STRIFStakedInCollectiveRewardsCanWithdraw(bool canWithdraw);
+    error STRIFSupportsERC165(bool _supports);
+    error STRIFSupportsICollectiveRewardsCheck(bool _supports);
+    error STRIFUnexpectedCanWithdraw(address _checkAddress);
+
+    /// @notice The address of the CollectiveRewards Contract
+    address public bimCheck;
+
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) { }
+
+    function mint(address account_, uint256 amount_) external {
+        _mint(account_, amount_);
+    }
+
+    function burn(address account_, uint256 amount_) external {
+        _burn(account_, amount_);
+    }
+
+    //checks CollectiveRewards for stake
+    modifier _checkCollectiveRewardsForStake(address staker, uint256 value) {
+        if (bimCheck != address(0)) {
+            try ICollectiveRewardsCheck(bimCheck).canWithdraw(staker, value) returns (bool canWithdraw) {
+                if (!canWithdraw) {
+                    revert STRIFStakedInCollectiveRewardsCanWithdraw(false);
+                }
+            } catch { }
+        }
+        _;
+    }
+
+    // checks that received address has method which can successfully be called
+    // before setting it to state
+    function setCollectiveRewardsAddress(address bimAddress) public {
+        if (!bimAddress.supportsERC165()) {
+            revert STRIFSupportsERC165(false);
+        }
+        if (!bimAddress.supportsInterface(type(ICollectiveRewardsCheck).interfaceId)) {
+            revert STRIFSupportsICollectiveRewardsCheck(false);
+        }
+
+        try ICollectiveRewardsCheck(bimAddress).canWithdraw(address(0), 1) returns (bool) {
+            bimCheck = bimAddress;
+        } catch {
+            revert STRIFUnexpectedCanWithdraw(bimAddress);
+        }
+    }
+
+    function _update(
+        address from,
+        address to,
+        uint256 value
+    )
+        internal
+        override
+        _checkCollectiveRewardsForStake(from, value)
+    {
+        super._update(from, to, value);
+    }
+}


### PR DESCRIPTION
## What

- We need to define the interface (and implement it) required by the StRIF contract to call the CR contacts before transferring or unstaking it.

## Refs

- [TOK-368](https://rsklabs.atlassian.net/browse/TOK-368)
