### PR TITLE
feat: give full rewardToken allowance to whitelisted gauges

### DIFF
--- a/src/BuilderRegistry.sol
+++ b/src/BuilderRegistry.sol
@@ -226,6 +226,9 @@ abstract contract BuilderRegistry is EpochTimeKeeper, Ownable2StepUpgradeable {
 
         builderState[builder_].whitelisted = true;
         gauge_ = _createGauge(builder_);
+
+        _rewardTokenApprove(address(gauge_), type(uint256).max);
+
         emit Whitelisted(builder_);
     }
 
@@ -244,6 +247,7 @@ abstract contract BuilderRegistry is EpochTimeKeeper, Ownable2StepUpgradeable {
         builderState[builder_].whitelisted = false;
 
         _haltGauge(_gauge);
+        _rewardTokenApprove(address(_gauge), 0);
 
         emit Dewhitelisted(builder_);
     }
@@ -502,6 +506,12 @@ abstract contract BuilderRegistry is EpochTimeKeeper, Ownable2StepUpgradeable {
         return _builderState.kycApproved && _builderState.whitelisted && !_builderState.revoked;
     }
 
+    /**
+     * @notice SponsorsManager override this function to modify gauge rewardToken allowance
+     * @param gauge_ gauge contract to approve rewardTokens
+     * @param value_ amount of rewardTokens to approve
+     */
+    function _rewardTokenApprove(address gauge_, uint256 value_) internal virtual { }
     /**
      * @notice SponsorsManager override this function to remove its shares
      * @param gauge_ gauge contract to be halted

--- a/src/SponsorsManager.sol
+++ b/src/SponsorsManager.sol
@@ -376,10 +376,19 @@ contract SponsorsManager is BuilderRegistry {
         // [N] = [N] * [N] / [N]
         uint256 _amountCoinbase = (_rewardShares * rewardsCoinbase_) / totalPotentialReward_;
         uint256 _builderKickback = getKickbackToApply(gaugeToBuilder[gauge_]);
-        IERC20(rewardToken).approve(address(gauge_), _amountERC20);
         return gauge_.notifyRewardAmountAndUpdateShares{ value: _amountCoinbase }(
             _amountERC20, _builderKickback, periodFinish_, epochStart_, epochDuration_
         );
+    }
+
+    /**
+     * @notice approves rewardTokens to a given gauge
+     * @dev give full allowance when it is whitelisted and remove it when it is dewhitelisted
+     * @param gauge_ gauge contract to approve rewardTokens
+     * @param value_ amount of rewardTokens to approve
+     */
+    function _rewardTokenApprove(address gauge_, uint256 value_) internal override {
+        IERC20(rewardToken).approve(gauge_, value_);
     }
 
     /**


### PR DESCRIPTION
## What

- Give full allowance to whitelisted gauges instead of approve them on each distribution

Before

<img width="803" alt="image" src="https://github.com/user-attachments/assets/d9fe0235-9866-473c-b671-9855865233e8">

<img width="785" alt="image" src="https://github.com/user-attachments/assets/e65f59b6-388e-4c50-bc08-d52b338987dd">

After

![image](https://github.com/user-attachments/assets/64d2a32d-d834-4038-bcbe-8ea448458079)

![image](https://github.com/user-attachments/assets/51db777c-cdb1-4bbe-8966-cd8e0ebb6ea1)

