### PR TITLE
fix: remove SponsorsManager as incentivizer in tests

### DIFF
--- a/docs/src/src/BuilderRegistry.sol/abstract.BuilderRegistry.md
+++ b/docs/src/src/BuilderRegistry.sol/abstract.BuilderRegistry.md
@@ -1,6 +1,6 @@
 # BuilderRegistry
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/BuilderRegistry.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/BuilderRegistry.sol)
 
 **Inherits:** [EpochTimeKeeper](/src/EpochTimeKeeper.sol/abstract.EpochTimeKeeper.md), Ownable2StepUpgradeable
 

--- a/docs/src/src/EpochTimeKeeper.sol/abstract.EpochTimeKeeper.md
+++ b/docs/src/src/EpochTimeKeeper.sol/abstract.EpochTimeKeeper.md
@@ -1,6 +1,6 @@
 # EpochTimeKeeper
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/EpochTimeKeeper.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/EpochTimeKeeper.sol)
 
 **Inherits:** [Upgradeable](/src/governance/Upgradeable.sol/abstract.Upgradeable.md)
 

--- a/docs/src/src/RewardDistributor.sol/contract.RewardDistributor.md
+++ b/docs/src/src/RewardDistributor.sol/contract.RewardDistributor.md
@@ -1,6 +1,6 @@
 # RewardDistributor
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/RewardDistributor.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/RewardDistributor.sol)
 
 **Inherits:** [Upgradeable](/src/governance/Upgradeable.sol/abstract.Upgradeable.md)
 

--- a/docs/src/src/SponsorsManager.sol/contract.SponsorsManager.md
+++ b/docs/src/src/SponsorsManager.sol/contract.SponsorsManager.md
@@ -1,6 +1,6 @@
 # SponsorsManager
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/SponsorsManager.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/SponsorsManager.sol)
 
 **Inherits:** [BuilderRegistry](/src/BuilderRegistry.sol/abstract.BuilderRegistry.md)
 

--- a/docs/src/src/gauge/Gauge.sol/contract.Gauge.md
+++ b/docs/src/src/gauge/Gauge.sol/contract.Gauge.md
@@ -1,6 +1,6 @@
 # Gauge
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/gauge/Gauge.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/gauge/Gauge.sol)
 
 **Inherits:** ReentrancyGuardUpgradeable
 

--- a/docs/src/src/gauge/GaugeBeacon.sol/contract.GaugeBeacon.md
+++ b/docs/src/src/gauge/GaugeBeacon.sol/contract.GaugeBeacon.md
@@ -1,6 +1,6 @@
 # GaugeBeacon
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/gauge/GaugeBeacon.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/gauge/GaugeBeacon.sol)
 
 **Inherits:** UpgradeableBeacon, [Governed](/src/governance/Governed.sol/abstract.Governed.md)
 

--- a/docs/src/src/gauge/GaugeFactory.sol/contract.GaugeFactory.md
+++ b/docs/src/src/gauge/GaugeFactory.sol/contract.GaugeFactory.md
@@ -1,6 +1,6 @@
 # GaugeFactory
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/gauge/GaugeFactory.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/gauge/GaugeFactory.sol)
 
 ## State Variables
 

--- a/docs/src/src/governance/ChangeExecutorRootstockCollective.sol/contract.ChangeExecutorRootstockCollective.md
+++ b/docs/src/src/governance/ChangeExecutorRootstockCollective.sol/contract.ChangeExecutorRootstockCollective.md
@@ -1,6 +1,6 @@
 # ChangeExecutorRootstockCollective
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/governance/ChangeExecutorRootstockCollective.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/governance/ChangeExecutorRootstockCollective.sol)
 
 **Inherits:** ReentrancyGuardUpgradeable, UUPSUpgradeable, [Governed](/src/governance/Governed.sol/abstract.Governed.md)
 

--- a/docs/src/src/governance/Governed.sol/abstract.Governed.md
+++ b/docs/src/src/governance/Governed.sol/abstract.Governed.md
@@ -1,6 +1,6 @@
 # Governed
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/governance/Governed.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/governance/Governed.sol)
 
 Base contract to be inherited by governed contracts
 

--- a/docs/src/src/governance/Upgradeable.sol/abstract.Upgradeable.md
+++ b/docs/src/src/governance/Upgradeable.sol/abstract.Upgradeable.md
@@ -1,6 +1,6 @@
 # Upgradeable
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/governance/Upgradeable.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/governance/Upgradeable.sol)
 
 **Inherits:** UUPSUpgradeable, [Governed](/src/governance/Governed.sol/abstract.Governed.md)
 

--- a/docs/src/src/governance/changerTemplates/WhitelistBuilderChangerTemplate.sol/contract.WhitelistBuilderChangerTemplate.md
+++ b/docs/src/src/governance/changerTemplates/WhitelistBuilderChangerTemplate.sol/contract.WhitelistBuilderChangerTemplate.md
@@ -1,6 +1,6 @@
 # WhitelistBuilderChangerTemplate
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/governance/changerTemplates/WhitelistBuilderChangerTemplate.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/governance/changerTemplates/WhitelistBuilderChangerTemplate.sol)
 
 **Inherits:**
 [IChangeContractRootstockCollective](/src/interfaces/IChangeContractRootstockCollective.sol/interface.IChangeContractRootstockCollective.md)

--- a/docs/src/src/interfaces/IChangeContractRootstockCollective.sol/interface.IChangeContractRootstockCollective.md
+++ b/docs/src/src/interfaces/IChangeContractRootstockCollective.sol/interface.IChangeContractRootstockCollective.md
@@ -1,6 +1,6 @@
 # IChangeContractRootstockCollective
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/interfaces/IChangeContractRootstockCollective.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/interfaces/IChangeContractRootstockCollective.sol)
 
 This interface is the one used by the governance system.
 

--- a/docs/src/src/interfaces/IChangeExecutorRootstockCollective.sol/interface.IChangeExecutorRootstockCollective.md
+++ b/docs/src/src/interfaces/IChangeExecutorRootstockCollective.sol/interface.IChangeExecutorRootstockCollective.md
@@ -1,6 +1,6 @@
 # IChangeExecutorRootstockCollective
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/interfaces/IChangeExecutorRootstockCollective.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/interfaces/IChangeExecutorRootstockCollective.sol)
 
 This interface is check if a changer is authotized by the governance system
 

--- a/docs/src/src/interfaces/ISponsorsManager.sol/interface.ISponsorsManager.md
+++ b/docs/src/src/interfaces/ISponsorsManager.sol/interface.ISponsorsManager.md
@@ -1,6 +1,6 @@
 # ISponsorsManager
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/interfaces/ISponsorsManager.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/interfaces/ISponsorsManager.sol)
 
 ## Functions
 

--- a/docs/src/src/libraries/UtilsLib.sol/library.UtilsLib.md
+++ b/docs/src/src/libraries/UtilsLib.sol/library.UtilsLib.md
@@ -1,6 +1,6 @@
 # UtilsLib
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/libraries/UtilsLib.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/libraries/UtilsLib.sol)
 
 ## State Variables
 

--- a/docs/src/src/mvp/SimplifiedRewardDistributorRootstockCollective.sol/contract.SimplifiedRewardDistributorRootstockCollective.md
+++ b/docs/src/src/mvp/SimplifiedRewardDistributorRootstockCollective.sol/contract.SimplifiedRewardDistributorRootstockCollective.md
@@ -1,6 +1,6 @@
 # SimplifiedRewardDistributorRootstockCollective
 
-[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/eab59780321156e2e502e0e3dd17da2f799b184f/src/mvp/SimplifiedRewardDistributorRootstockCollective.sol)
+[Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/9e93ef13dfa486a88912b2b33742981b36e991ee/src/mvp/SimplifiedRewardDistributorRootstockCollective.sol)
 
 **Inherits:** [Upgradeable](/src/governance/Upgradeable.sol/abstract.Upgradeable.md), ReentrancyGuardUpgradeable
 


### PR DESCRIPTION
## What

- `SponsorsManager` is used as incentivizer in several tests, but approving `rewardToken`s for incentives overlaps with max reward approval in whitelisting process. Since `SponsorsManager` won't be incentivizing gauges directly in real life, it's safe to simply remove it from the tests without taking any more precautions 

