### PR TITLE
fix: positive allocation on halted gauge

### DIFF
--- a/docs/src/src/BuilderRegistry.sol/abstract.BuilderRegistry.md
+++ b/docs/src/src/BuilderRegistry.sol/abstract.BuilderRegistry.md
@@ -1,6 +1,6 @@
 # BuilderRegistry
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/BuilderRegistry.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/BuilderRegistry.sol)
 
 **Inherits:** [EpochTimeKeeper](/src/EpochTimeKeeper.sol/abstract.EpochTimeKeeper.md)
 

--- a/docs/src/src/EpochTimeKeeper.sol/abstract.EpochTimeKeeper.md
+++ b/docs/src/src/EpochTimeKeeper.sol/abstract.EpochTimeKeeper.md
@@ -1,6 +1,6 @@
 # EpochTimeKeeper
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/EpochTimeKeeper.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/EpochTimeKeeper.sol)
 
 **Inherits:** [Upgradeable](/src/mvp/Upgradeable.sol/abstract.Upgradeable.md)
 

--- a/docs/src/src/RewardDistributor.sol/contract.RewardDistributor.md
+++ b/docs/src/src/RewardDistributor.sol/contract.RewardDistributor.md
@@ -1,6 +1,6 @@
 # RewardDistributor
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/RewardDistributor.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/RewardDistributor.sol)
 
 **Inherits:** [Upgradeable](/src/mvp/Upgradeable.sol/abstract.Upgradeable.md)
 

--- a/docs/src/src/SponsorsManager.sol/contract.SponsorsManager.md
+++ b/docs/src/src/SponsorsManager.sol/contract.SponsorsManager.md
@@ -1,6 +1,6 @@
 # SponsorsManager
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/SponsorsManager.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/SponsorsManager.sol)
 
 **Inherits:** [BuilderRegistry](/src/BuilderRegistry.sol/abstract.BuilderRegistry.md)
 
@@ -499,4 +499,10 @@ error DistributionPeriodDidNotStart();
 
 ```solidity
 error BeforeDistribution();
+```
+
+### PositiveAllocationOnHaltedGauge
+
+```solidity
+error PositiveAllocationOnHaltedGauge();
 ```

--- a/docs/src/src/gauge/Gauge.sol/contract.Gauge.md
+++ b/docs/src/src/gauge/Gauge.sol/contract.Gauge.md
@@ -1,6 +1,6 @@
 # Gauge
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/gauge/Gauge.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/gauge/Gauge.sol)
 
 **Inherits:** ReentrancyGuardUpgradeable
 

--- a/docs/src/src/gauge/GaugeBeacon.sol/contract.GaugeBeacon.md
+++ b/docs/src/src/gauge/GaugeBeacon.sol/contract.GaugeBeacon.md
@@ -1,6 +1,6 @@
 # GaugeBeacon
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/gauge/GaugeBeacon.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/gauge/GaugeBeacon.sol)
 
 **Inherits:** UpgradeableBeacon
 

--- a/docs/src/src/gauge/GaugeFactory.sol/contract.GaugeFactory.md
+++ b/docs/src/src/gauge/GaugeFactory.sol/contract.GaugeFactory.md
@@ -1,6 +1,6 @@
 # GaugeFactory
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/gauge/GaugeFactory.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/gauge/GaugeFactory.sol)
 
 ## State Variables
 

--- a/docs/src/src/governance/ChangeExecutorRootstockCollective.sol/contract.ChangeExecutorRootstockCollective.md
+++ b/docs/src/src/governance/ChangeExecutorRootstockCollective.sol/contract.ChangeExecutorRootstockCollective.md
@@ -1,11 +1,14 @@
 # ChangeExecutorRootstockCollective
 
-<<<<<<< HEAD
+<<<<<<< HEAD <<<<<<< HEAD
 [Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/93d5161844768d71b8f7420d54b86b3a341b2a7b/src/governance/ChangeExecutorRootstockCollective.sol)
 =======
 [Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/4458056df04f5875676ab19eeb61c095640acd7a/src/governance/ChangeExecutorRootstockCollective.sol)
 
-> > > > > > > e514e20 (docs: automated docgen by GitHub Action)
+> > > > > > > # e514e20 (docs: automated docgen by GitHub Action)
+> > > > > > >
+> > > > > > > [Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/07de5fea7631b345ab1f8d59e79b48cb3bd6e6d2/src/governance/ChangeExecutorRootstockCollective.sol)
+> > > > > > > 4dd012a (docs: automated docgen by GitHub Action)
 
 **Inherits:** ReentrancyGuardUpgradeable, UUPSUpgradeable, [Governed](/src/governance/Governed.sol/abstract.Governed.md)
 

--- a/docs/src/src/governance/GovernanceManager.sol/contract.GovernanceManager.md
+++ b/docs/src/src/governance/GovernanceManager.sol/contract.GovernanceManager.md
@@ -1,6 +1,6 @@
 # GovernanceManager
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/governance/GovernanceManager.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/governance/GovernanceManager.sol)
 
 **Inherits:** UUPSUpgradeable,
 [IGovernanceManager](/src/interfaces/IGovernanceManager.sol/interface.IGovernanceManager.md)

--- a/docs/src/src/governance/Governed.sol/abstract.Governed.md
+++ b/docs/src/src/governance/Governed.sol/abstract.Governed.md
@@ -1,11 +1,14 @@
 # Governed
 
-<<<<<<< HEAD
+<<<<<<< HEAD <<<<<<< HEAD
 [Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/93d5161844768d71b8f7420d54b86b3a341b2a7b/src/governance/Governed.sol)
 =======
 [Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/4458056df04f5875676ab19eeb61c095640acd7a/src/governance/Governed.sol)
 
-> > > > > > > e514e20 (docs: automated docgen by GitHub Action)
+> > > > > > > # e514e20 (docs: automated docgen by GitHub Action)
+> > > > > > >
+> > > > > > > [Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/07de5fea7631b345ab1f8d59e79b48cb3bd6e6d2/src/governance/Governed.sol)
+> > > > > > > 4dd012a (docs: automated docgen by GitHub Action)
 
 Base contract to be inherited by governed contracts
 

--- a/docs/src/src/governance/Upgradeable.sol/abstract.Upgradeable.md
+++ b/docs/src/src/governance/Upgradeable.sol/abstract.Upgradeable.md
@@ -1,6 +1,6 @@
 # Upgradeable
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/governance/Upgradeable.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/governance/Upgradeable.sol)
 
 **Inherits:** UUPSUpgradeable
 

--- a/docs/src/src/governance/changerTemplates/WhitelistBuilderChangerTemplate.sol/contract.WhitelistBuilderChangerTemplate.md
+++ b/docs/src/src/governance/changerTemplates/WhitelistBuilderChangerTemplate.sol/contract.WhitelistBuilderChangerTemplate.md
@@ -1,6 +1,6 @@
 # WhitelistBuilderChangerTemplate
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/governance/changerTemplates/WhitelistBuilderChangerTemplate.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/governance/changerTemplates/WhitelistBuilderChangerTemplate.sol)
 
 **Inherits:**
 [IChangeContractRootstockCollective](/src/interfaces/IChangeContractRootstockCollective.sol/interface.IChangeContractRootstockCollective.md)

--- a/docs/src/src/interfaces/IChangeContractRootstockCollective.sol/interface.IChangeContractRootstockCollective.md
+++ b/docs/src/src/interfaces/IChangeContractRootstockCollective.sol/interface.IChangeContractRootstockCollective.md
@@ -1,6 +1,6 @@
 # IChangeContractRootstockCollective
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/interfaces/IChangeContractRootstockCollective.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/interfaces/IChangeContractRootstockCollective.sol)
 
 This interface is the one used by the governance system.
 

--- a/docs/src/src/interfaces/IChangeExecutorRootstockCollective.sol/interface.IChangeExecutorRootstockCollective.md
+++ b/docs/src/src/interfaces/IChangeExecutorRootstockCollective.sol/interface.IChangeExecutorRootstockCollective.md
@@ -1,11 +1,14 @@
 # IChangeExecutorRootstockCollective
 
-<<<<<<< HEAD
+<<<<<<< HEAD <<<<<<< HEAD
 [Git Source](https://github.com/RootstockCollective/collective-rewards-sc/blob/93d5161844768d71b8f7420d54b86b3a341b2a7b/src/interfaces/IChangeExecutorRootstockCollective.sol)
 =======
 [Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/4458056df04f5875676ab19eeb61c095640acd7a/src/interfaces/IChangeExecutorRootstockCollective.sol)
 
-> > > > > > > e514e20 (docs: automated docgen by GitHub Action)
+> > > > > > > # e514e20 (docs: automated docgen by GitHub Action)
+> > > > > > >
+> > > > > > > [Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/07de5fea7631b345ab1f8d59e79b48cb3bd6e6d2/src/interfaces/IChangeExecutorRootstockCollective.sol)
+> > > > > > > 4dd012a (docs: automated docgen by GitHub Action)
 
 This interface is check if a changer is authotized by the governance system
 

--- a/docs/src/src/interfaces/IGovernanceManager.sol/interface.IGovernanceManager.md
+++ b/docs/src/src/interfaces/IGovernanceManager.sol/interface.IGovernanceManager.md
@@ -1,6 +1,6 @@
 # IGovernanceManager
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/interfaces/IGovernanceManager.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/interfaces/IGovernanceManager.sol)
 
 ## Functions
 

--- a/docs/src/src/interfaces/ISponsorsManager.sol/interface.ISponsorsManager.md
+++ b/docs/src/src/interfaces/ISponsorsManager.sol/interface.ISponsorsManager.md
@@ -1,6 +1,6 @@
 # ISponsorsManager
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/interfaces/ISponsorsManager.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/interfaces/ISponsorsManager.sol)
 
 ## Functions
 

--- a/docs/src/src/libraries/UtilsLib.sol/library.UtilsLib.md
+++ b/docs/src/src/libraries/UtilsLib.sol/library.UtilsLib.md
@@ -1,6 +1,6 @@
 # UtilsLib
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/libraries/UtilsLib.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/libraries/UtilsLib.sol)
 
 ## State Variables
 

--- a/docs/src/src/mvp/ChangeExecutorRootstockCollective.sol/contract.ChangeExecutorRootstockCollective.md
+++ b/docs/src/src/mvp/ChangeExecutorRootstockCollective.sol/contract.ChangeExecutorRootstockCollective.md
@@ -1,6 +1,6 @@
 # ChangeExecutorRootstockCollective
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/mvp/ChangeExecutorRootstockCollective.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/mvp/ChangeExecutorRootstockCollective.sol)
 
 **Inherits:** ReentrancyGuardUpgradeable, UUPSUpgradeable, [Governed](/src/mvp/Governed.sol/abstract.Governed.md)
 

--- a/docs/src/src/mvp/Governed.sol/abstract.Governed.md
+++ b/docs/src/src/mvp/Governed.sol/abstract.Governed.md
@@ -1,6 +1,6 @@
 # Governed
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/mvp/Governed.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/mvp/Governed.sol)
 
 Base contract to be inherited by governed contracts
 

--- a/docs/src/src/mvp/IChangeExecutorRootstockCollective.sol/interface.IChangeExecutorRootstockCollective.md
+++ b/docs/src/src/mvp/IChangeExecutorRootstockCollective.sol/interface.IChangeExecutorRootstockCollective.md
@@ -1,6 +1,6 @@
 # IChangeExecutorRootstockCollective
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/mvp/IChangeExecutorRootstockCollective.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/mvp/IChangeExecutorRootstockCollective.sol)
 
 This interface is check if a changer is authotized by the governance system
 

--- a/docs/src/src/mvp/SimplifiedRewardDistributorRootstockCollective.sol/contract.SimplifiedRewardDistributorRootstockCollective.md
+++ b/docs/src/src/mvp/SimplifiedRewardDistributorRootstockCollective.sol/contract.SimplifiedRewardDistributorRootstockCollective.md
@@ -1,6 +1,6 @@
 # SimplifiedRewardDistributorRootstockCollective
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/mvp/SimplifiedRewardDistributorRootstockCollective.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/mvp/SimplifiedRewardDistributorRootstockCollective.sol)
 
 **Inherits:** [Upgradeable](/src/mvp/Upgradeable.sol/abstract.Upgradeable.md), ReentrancyGuardUpgradeable
 

--- a/docs/src/src/mvp/Upgradeable.sol/abstract.Upgradeable.md
+++ b/docs/src/src/mvp/Upgradeable.sol/abstract.Upgradeable.md
@@ -1,6 +1,6 @@
 # Upgradeable
 
-[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/6055db6ff187da599d0ad220410df3adfbe4a79d/src/mvp/Upgradeable.sol)
+[Git Source](https://github.com/rsksmart/collective-rewards-sc/blob/ae40e66d2b99b4caf83133f94d38374097b51ea3/src/mvp/Upgradeable.sol)
 
 **Inherits:** UUPSUpgradeable, [Governed](/src/mvp/Governed.sol/abstract.Governed.md)
 

--- a/src/SponsorsManager.sol
+++ b/src/SponsorsManager.sol
@@ -26,6 +26,7 @@ contract SponsorsManager is BuilderRegistry {
     error NotInDistributionPeriod();
     error DistributionPeriodDidNotStart();
     error BeforeDistribution();
+    error PositiveAllocationOnHaltedGauge();
 
     // -----------------------------
     // ----------- Events ----------
@@ -282,11 +283,10 @@ contract SponsorsManager is BuilderRegistry {
 
         // halted gauges are not taken on account for the rewards; newTotalPotentialReward_ == totalPotentialReward_
         if (isGaugeHalted(address(gauge_))) {
-            if (_isNegative) {
-                newSponsorTotalAllocation_ = sponsorTotalAllocation_ - _allocationDeviation;
-            } else {
-                newSponsorTotalAllocation_ = sponsorTotalAllocation_ + _allocationDeviation;
+            if (!_isNegative) {
+                revert PositiveAllocationOnHaltedGauge();
             }
+            newSponsorTotalAllocation_ = sponsorTotalAllocation_ - _allocationDeviation;
             return (newSponsorTotalAllocation_, totalPotentialReward_);
         }
 

--- a/src/gauge/Gauge.sol
+++ b/src/gauge/Gauge.sol
@@ -314,7 +314,7 @@ contract Gauge is ReentrancyGuardUpgradeable {
 
         // to avoid dealing with signed integers we add allocation if the new one is bigger than the previous one
         uint256 _previousAllocation = allocationOf[sponsor_];
-        if (allocation_ >= _previousAllocation) {
+        if (allocation_ > _previousAllocation) {
             allocationDeviation_ = allocation_ - _previousAllocation;
             rewardSharesDeviation_ = allocationDeviation_ * timeUntilNextEpoch_;
             totalAllocation += allocationDeviation_;

--- a/test/HaltedBuilderBehavior.t.sol
+++ b/test/HaltedBuilderBehavior.t.sol
@@ -85,7 +85,7 @@ abstract contract HaltedBuilderBehavior is BaseTest {
 
     /**
      * SCENARIO: builder is halted in the middle of an epoch having allocation.
-     *  Alice modifies reduce its allocation but the total reward shares don't change
+     *  Alice reduce its allocation but the total reward shares don't change
      *  and the sponsorTotalAllocation is updated
      */
     function test_NegativeAllocationOnHaltedGauge() public {
@@ -251,7 +251,7 @@ abstract contract HaltedBuilderBehavior is BaseTest {
 
     /**
      * SCENARIO: builder is halted in the middle of an epoch having allocation.
-     *  If the builder increase allocations tx fails
+     *  If the builder increases allocations tx fails
      */
     function test_HaltedGaugeCannotIncreaseAllocations() public {
         // GIVEN alice and bob allocate to builder and builder2

--- a/test/ResumeBuilderBehavior.t.sol
+++ b/test/ResumeBuilderBehavior.t.sol
@@ -225,10 +225,10 @@ abstract contract ResumeBuilderBehavior is BaseTest {
         _initialState();
 
         // WHEN alice adds allocations to halted builder
-        vm.prank(alice);
-        sponsorsManager.allocate(gauge, 4 ether);
-        // THEN gauge rewardShares is 1814400 ether = 2 * 1/2 WEEK + 4 * 1/2 WEEK
-        assertEq(gauge.rewardShares(), 1_814_400 ether);
+        vm.startPrank(alice);
+        sponsorsManager.allocate(gauge, 1 ether);
+        // THEN gauge rewardShares is 907200 ether = 2 * 1/2 WEEK + 1 * 1/2 WEEK
+        assertEq(gauge.rewardShares(), 907_200 ether);
         // THEN total allocation didn't change is 8467200 ether = 14 * 1 WEEK
         assertEq(sponsorsManager.totalPotentialReward(), 8_467_200 ether);
 
@@ -238,10 +238,10 @@ abstract contract ResumeBuilderBehavior is BaseTest {
         // WHEN gauge is resumed
         _resumeGauge();
 
-        // THEN gauge rewardShares is 1814400 ether = 2 * 1/2 WEEK + 4 * 1/2 WEEK
-        assertEq(gauge.rewardShares(), 1_814_400 ether);
-        // THEN total allocation didn't change is 10281600 ether = gauge(2 * 1/2 WEEK + 4 * 1/2 WEEK) + gauge2(14 * 1
+        // THEN gauge rewardShares is 907200 ether = 2 * 1/2 WEEK + 1 * 1/2 WEEK
+        assertEq(gauge.rewardShares(), 907_200 ether);
+        // THEN total allocation didn't change is 9374400 ether = gauge(2 * 1/2 WEEK + 1 * 1/2 WEEK) + gauge2(14 * 1
         // WEEK)
-        assertEq(sponsorsManager.totalPotentialReward(), 10_281_600 ether);
+        assertEq(sponsorsManager.totalPotentialReward(), 9_374_400 ether);
     }
 }

--- a/test/SponsorsManager.t.sol
+++ b/test/SponsorsManager.t.sol
@@ -352,11 +352,12 @@ contract SponsorsManagerTest is BaseTest {
             // THEN new gauge is added in the last index
             assertEq(sponsorsManager.getGaugeAt(gaugesArray.length - 1), address(_newGauge));
         }
+        vm.prank(alice);
+        sponsorsManager.allocateBatch(gaugesArray, allocationsArray);
+
         vm.prank(builder2);
         sponsorsManager.revokeBuilder();
 
-        vm.prank(alice);
-        sponsorsManager.allocateBatch(gaugesArray, allocationsArray);
         //  AND 2 ether reward are added
         sponsorsManager.notifyRewardAmount(2 ether);
         // AND distribution window starts

--- a/test/fuzz/RevokeBuilder.t.sol
+++ b/test/fuzz/RevokeBuilder.t.sol
@@ -127,6 +127,10 @@ contract RevokeBuilderFuzzTest is BaseFuzz {
                         _expectedTotalPotentialReward -= (_allocationBefore - sponsorsAllocations[i][j])
                             * sponsorsManager.timeUntilNextEpoch(block.timestamp);
                     }
+                } else {
+                    if (sponsorsAllocations[i][j] > _allocationBefore) {
+                        sponsorsAllocations[i][j] = _allocationBefore;
+                    }
                 }
             }
             vm.prank(sponsorsArray[i]);

--- a/test/invariant/handlers/AllocateHandler.sol
+++ b/test/invariant/handlers/AllocateHandler.sol
@@ -53,6 +53,12 @@ contract AllocateHandler is BaseHandler {
 
         Gauge _gauge = baseTest.gaugesArray(gaugeIndex_);
         uint256 _allocationBefore = sponsorGaugeAllocation[msg.sender][_gauge];
+        if (sponsorsManager.isGaugeHalted(address(_gauge))) {
+            if (allocation_ > _allocationBefore) {
+                allocation_ = _allocationBefore;
+            }
+        }
+
         sponsorGaugeAllocation[msg.sender][_gauge] = allocation_;
 
         if (!sponsorExists[msg.sender]) {

--- a/test/invariant/handlers/BuilderHandler.sol
+++ b/test/invariant/handlers/BuilderHandler.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.20;
 
 import { BaseHandler, TimeManager } from "./BaseHandler.sol";
 import { BaseTest } from "../../BaseTest.sol";
-import { Gauge } from "src/gauge/Gauge.sol";
 
 contract BuilderHandler is BaseHandler {
     constructor(BaseTest baseTest_, TimeManager timeManager_) BaseHandler(baseTest_, timeManager_) { }

--- a/test/invariant/handlers/DistributionHandler.sol
+++ b/test/invariant/handlers/DistributionHandler.sol
@@ -5,7 +5,6 @@ import { BaseHandler, TimeManager } from "./BaseHandler.sol";
 import { BaseTest } from "../../BaseTest.sol";
 import { ERC20Mock } from "test/mock/ERC20Mock.sol";
 import { RewardDistributor } from "src/RewardDistributor.sol";
-import { Gauge } from "src/gauge/Gauge.sol";
 
 contract DistributionHandler is BaseHandler {
     ERC20Mock public rewardToken;

--- a/test/invariant/handlers/EpochHandler.sol
+++ b/test/invariant/handlers/EpochHandler.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.20;
 
 import { BaseHandler, TimeManager } from "./BaseHandler.sol";
 import { BaseTest } from "../../BaseTest.sol";
-import { Gauge } from "src/gauge/Gauge.sol";
 
 contract EpochHandler is BaseHandler {
     constructor(BaseTest baseTest_, TimeManager timeManager_) BaseHandler(baseTest_, timeManager_) { }

--- a/test/invariant/handlers/IncentivizeHandler.sol
+++ b/test/invariant/handlers/IncentivizeHandler.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.20;
 import { BaseHandler, TimeManager } from "./BaseHandler.sol";
 import { BaseTest } from "../../BaseTest.sol";
 import { ERC20Mock } from "test/mock/ERC20Mock.sol";
-import { RewardDistributor } from "src/RewardDistributor.sol";
 import { Gauge } from "src/gauge/Gauge.sol";
 
 contract IncentivizeHandler is BaseHandler {


### PR DESCRIPTION
## What

_Issue_
If a gauge is `halted` in epoch `x` and in epoch `x+1` is `resumed`, we need to take into account the following requirements. 

1. We need to use the `epochDuration` to avoid penalizing the backers that stayed in the gauge during the time that was `halted`
2. By using `epochDuration` we allowed the `builders` to increase their allocation at the end of the `epoch`, boosting their `totalPotentialReward` since the calculation will be done with the assumption that those allocations were there for the whole epoch. 

_Fix_
Do not allow `gauge` to increase their allocation while is `halted`. 

