### PR TITLE
Lower ci verbosity

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -31,7 +31,7 @@ fail_on_revert = true
 runs = 200
 
 [profile.ci]
-verbosity = 2
+verbosity = 1
 
 [fmt]
 bracket_spacing = true


### PR DESCRIPTION
## What

-lower the CI test verbosity

## Why

- it's "polluting" the output too much after we added invariants: see this foe example: https://github.com/RootstockCollective/collective-rewards-sc/actions/runs/11684901949/job/32537136636?pr=95

## Testing

- Run the CI test job

## Refs

- Not linked with any Jira ticket
