### PR TITLE
fix: include params when deploying GovernanceManager from main script

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -22,7 +22,6 @@ contract Deploy is Broadcaster, OutputWriter {
     address private _kycApproverAddress;
     address private _governorAddress;
     address private _foundationTreasuryAddress;
-    address private _kycApproverAddress;
     uint32 private _cycleDuration;
     uint24 private _cycleStartOffset;
     uint128 private _rewardPercentageCooldown;

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -20,7 +20,9 @@ contract Deploy is Broadcaster, OutputWriter {
     address private _rewardTokenAddress;
     address private _stakingTokenAddress;
     address private _kycApproverAddress;
+    address private _governorAddress;
     address private _foundationTreasuryAddress;
+    address private _kycApproverAddress;
     uint32 private _cycleDuration;
     uint24 private _cycleStartOffset;
     uint128 private _rewardPercentageCooldown;
@@ -28,7 +30,9 @@ contract Deploy is Broadcaster, OutputWriter {
     function setUp() public {
         _rewardTokenAddress = vm.envAddress("REWARD_TOKEN_ADDRESS");
         _stakingTokenAddress = vm.envAddress("STAKING_TOKEN_ADDRESS");
+        _governorAddress = vm.envAddress("GOVERNOR_ADDRESS");
         _foundationTreasuryAddress = vm.envAddress("FOUNDATION_TREASURY_ADDRESS");
+        _kycApproverAddress = vm.envAddress("KYC_APPROVER_ADDRESS");
         _cycleDuration = uint32(vm.envUint("CYCLE_DURATION"));
         _cycleStartOffset = uint24(vm.envUint("CYCLE_START_OFFSET"));
         _rewardPercentageCooldown = uint128(vm.envUint("REWARD_PERCENTAGE_COOLDOWN"));
@@ -40,7 +44,9 @@ contract Deploy is Broadcaster, OutputWriter {
         (
             GovernanceManagerRootstockCollective _governanceManagerProxy,
             GovernanceManagerRootstockCollective _governanceManagerImpl
-        ) = new GovernanceManagerRootstockCollectiveDeployer().run();
+        ) = new GovernanceManagerRootstockCollectiveDeployer().run(
+            _governorAddress, _foundationTreasuryAddress, _kycApproverAddress
+        );
         saveWithProxy(
             "GovernanceManagerRootstockCollective", address(_governanceManagerImpl), address(_governanceManagerProxy)
         );


### PR DESCRIPTION
## What

- Include env vars when deploying GovernanceManager from the main script

## Why

- To follow the same approach used for the others
