### PR TITLE
Adjust strif canWithdraw interaction

### DIFF
--- a/src/BackersManagerRootstockCollective.sol
+++ b/src/BackersManagerRootstockCollective.sol
@@ -140,14 +140,16 @@ contract BackersManagerRootstockCollective is
 
     /**
      * @notice returns true if can withdraw, remaining balance should exceed the current allocation
+     * @dev user token balance should already account for the update, meaning the check
+     * is applied AFTER the withdraw accounting has become effective.
      * @param targetAddress_ address who wants to withdraw stakingToken
-     * @param value_ amount of stakingToken to withdraw
+     * param value_ amount of stakingToken to withdraw, not used on current version
      */
-    function canWithdraw(address targetAddress_, uint256 value_) external view returns (bool) {
+    function canWithdraw(address targetAddress_, uint256 /*value_*/ ) external view returns (bool) {
         uint256 _allocation = backerTotalAllocation[targetAddress_];
         if (_allocation == 0) return true;
 
-        return stakingToken.balanceOf(targetAddress_) >= _allocation + value_;
+        return stakingToken.balanceOf(targetAddress_) >= _allocation;
     }
 
     /**

--- a/test/mock/StakingTokenMock.sol
+++ b/test/mock/StakingTokenMock.sol
@@ -32,6 +32,8 @@ contract StakingTokenMock is ERC20 {
 
     //checks CollectiveRewards for stake
     modifier _checkCollectiveRewardsForStake(address staker, uint256 value) {
+        _;
+        // The check is applied after the fnc modified, so that if there is any revert there, it takes priority
         if (collectiveRewardsCheck != address(0)) {
             try ICollectiveRewardsCheckRootstockCollective(collectiveRewardsCheck).canWithdraw(staker, value) returns (
                 bool canWithdraw
@@ -41,7 +43,6 @@ contract StakingTokenMock is ERC20 {
                 }
             } catch { }
         }
-        _;
     }
 
     // checks that received address has method which can successfully be called


### PR DESCRIPTION
## What & Why

After [this](https://github.com/RootstockCollective/dao-contracts-private/pull/1#discussion_r1829016269) interaction, DAO team invert the order on how the `canWithdraw` function is invoke from the stRif to the CRC. After this change, we need to adjust accordingly.

## Testing

- All stRif movements test cases should still be valid, with the only difference being that trying to send mode balance that what you have, should fail with default ERC20 error now.

## Refs

- https://rsklabs.atlassian.net/browse/TOK-465
- StRif PR: https://github.com/RootstockCollective/dao-contracts-private/pull/1
