### PR TITLE
chore: change deep test job name

### DIFF
--- a/.github/workflows/test-deep.yml
+++ b/.github/workflows/test-deep.yml
@@ -11,7 +11,7 @@ on:
       - "main"
 
 jobs:
-  test:
+  deep-test:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out the repo"


### PR DESCRIPTION
## What

- change the deep test job name

## Why

- so we can remove it from the required checks (at the moment we have 2 tests jobs, so we either enable or disable both)
