### PR TITLE
[ TOK-481] RSCR-04: Don't allow sending rewards to backersManager with no active gauges

### DIFF
--- a/src/BackersManagerRootstockCollective.sol
+++ b/src/BackersManagerRootstockCollective.sol
@@ -31,6 +31,7 @@ contract BackersManagerRootstockCollective is
     error DistributionPeriodDidNotStart();
     error BeforeDistribution();
     error PositiveAllocationOnHaltedGauge();
+    error NoGaugesForDistribution();
 
     // -----------------------------
     // ----------- Events ----------
@@ -207,8 +208,10 @@ contract BackersManagerRootstockCollective is
     /**
      * @notice transfers reward tokens from the sender to be distributed to the gauges
      * @dev reverts if it is called during the distribution period
+     *  reverts if there are no gauges available for the distribution
      */
     function notifyRewardAmount(uint256 amount_) external payable notInDistributionPeriod {
+        if (getGaugesLength() == 0) revert NoGaugesForDistribution();
         if (msg.value > 0) {
             rewardsCoinbase += msg.value;
             emit NotifyReward(UtilsLib._COINBASE_ADDRESS, msg.sender, msg.value);

--- a/test/BackersManagerRootstockCollective.t.sol
+++ b/test/BackersManagerRootstockCollective.t.sol
@@ -388,6 +388,38 @@ contract BackersManagerRootstockCollectiveTest is BaseTest {
     }
 
     /**
+     * SCENARIO: notifyRewardAmount reverts when there are no active gauges
+     */
+    function test_NotifyRewardAmountWithNoActiveBuilders() public {
+        // GIVEN a BackerManager contract
+        //   WHEN both existing builders get revoked
+        vm.startPrank(kycApprover);
+        backersManager.revokeBuilderKYC(builder);
+        backersManager.revokeBuilderKYC(builder2);
+        vm.stopPrank();
+
+        // THEN there are no active gauges
+        assertEq(backersManager.getGaugesLength(), 0);
+        // THEN all there are 2 halted gauges
+        assertEq(backersManager.getHaltedGaugesLength(), 2);
+
+        // AND notifyRewardAmount is called with coinbase
+        //  THEN it reverts with NoGaugesForDistribution error
+        vm.expectRevert(BackersManagerRootstockCollective.NoGaugesForDistribution.selector);
+        backersManager.notifyRewardAmount{ value: 1 ether }(0 ether);
+
+        // AND notifyRewardAmount is called with rewardTken
+        //  THEN it reverts with NoGaugesForDistribution error
+        vm.expectRevert(BackersManagerRootstockCollective.NoGaugesForDistribution.selector);
+        backersManager.notifyRewardAmount(0 ether);
+
+        // AND notifyRewardAmount is called with both coinbase and rewardToken
+        //  THEN it reverts with NoGaugesForDistribution error
+        vm.expectRevert(BackersManagerRootstockCollective.NoGaugesForDistribution.selector);
+        backersManager.notifyRewardAmount{ value: 1 ether }(1 ether);
+    }
+
+    /**
      * SCENARIO: notifyRewardAmount is called using Coinbase and values are updated
      */
     function test_NotifyRewardAmountCoinbase() public {


### PR DESCRIPTION
## What

- If there are no active gauges (there are no gauges or they are all halted), revert with an error when trying to call `notifyRewardAmount` from the `backersManager` contract

## Why

-  As raised in RSCR-04 from the last security report, if a distribution happens with no active gauges then the existing rewards get locked in the `backersManager` contract and not taken into account for following distributions. 

OBS: while this fix prevents the foundation from sending rewards and executing the distribution (the same as when we have no allocations) it doesn't prevent rewards from getting locked in a scenario like this:

1. rewards are sent to the `backersManager` with active gauges
2. all gauges get revoked
3. someone starts directly the distribution (not from the `rewardsDistributor` but form the `backersManager`)

Then rewards get effectively locked.

The likeliness of this happening is very low and there are always ways to recover those funds, so it won't be addressed in the code.

## Refs

- [Task](https://rsklabs.atlassian.net/browse/TOK-481)
