### PR TITLE
[TOK-481] Rename builderRewardPercentage to backerRewardPercentage

### DIFF
--- a/src/BackersManagerRootstockCollective.sol
+++ b/src/BackersManagerRootstockCollective.sol
@@ -434,9 +434,9 @@ contract BackersManagerRootstockCollective is
         uint256 _amountERC20 = (_rewardShares * rewardsERC20_) / totalPotentialReward_;
         // [N] = [N] * [N] / [N]
         uint256 _amountCoinbase = (_rewardShares * rewardsCoinbase_) / totalPotentialReward_;
-        uint256 _builderRewardPercentage = getRewardPercentageToApply(gaugeToBuilder[gauge_]);
+        uint256 _backerRewardPercentage = getRewardPercentageToApply(gaugeToBuilder[gauge_]);
         return gauge_.notifyRewardAmountAndUpdateShares{ value: _amountCoinbase }(
-            _amountERC20, _builderRewardPercentage, periodFinish_, cycleStart_, cycleDuration_
+            _amountERC20, _backerRewardPercentage, periodFinish_, cycleStart_, cycleDuration_
         );
     }
 

--- a/src/BuilderRegistryRootstockCollective.sol
+++ b/src/BuilderRegistryRootstockCollective.sol
@@ -94,7 +94,7 @@ abstract contract BuilderRegistryRootstockCollective is CycleTimeKeeperRootstock
     mapping(address builder => BuilderState state) public builderState;
     /// @notice map of builders reward receiver
     mapping(address builder => address rewardReceiver) public builderRewardReceiver;
-    /// @notice map of backers reward percentage data
+    /// @notice map of builder's backers reward percentage data
     mapping(address builder => RewardPercentageData rewardPercentageData) public backerRewardPercentage;
     /// @notice array of all the operational gauges
     EnumerableSet.AddressSet internal _gauges;
@@ -341,7 +341,7 @@ abstract contract BuilderRegistryRootstockCollective is CycleTimeKeeperRootstock
     }
 
     /**
-     * @notice set a backer reward percentage
+     * @notice allows a builder to set his backers reward percentage
      * @dev reverts if builder is not operational
      * @param rewardPercentage_ reward percentage(100% == 1 ether)
      */

--- a/src/gauge/GaugeRootstockCollective.sol
+++ b/src/gauge/GaugeRootstockCollective.sol
@@ -397,7 +397,7 @@ contract GaugeRootstockCollective is ReentrancyGuardUpgradeable {
      * @notice called on the reward distribution. Transfers reward tokens from backerManger to this contract
      * @dev reverts if caller is not the backersManager contract
      * @param amountERC20_ amount of ERC20 rewards
-     * @param builderRewardPercentage_  builder reward percentage percentage
+     * @param backerRewardPercentage_  backers reward percentage
      * @param periodFinish_ timestamp end of current rewards period
      * @param cycleStart_ Collective Rewards cycle start timestamp
      * @param cycleDuration_ Collective Rewards cycle time duration
@@ -405,7 +405,7 @@ contract GaugeRootstockCollective is ReentrancyGuardUpgradeable {
      */
     function notifyRewardAmountAndUpdateShares(
         uint256 amountERC20_,
-        uint256 builderRewardPercentage_,
+        uint256 backerRewardPercentage_,
         uint256 periodFinish_,
         uint256 cycleStart_,
         uint256 cycleDuration_
@@ -415,8 +415,8 @@ contract GaugeRootstockCollective is ReentrancyGuardUpgradeable {
         onlyBackersManager
         returns (uint256 newGaugeRewardShares_)
     {
-        uint256 _backerAmountERC20 = UtilsLib._mulPrec(builderRewardPercentage_, amountERC20_);
-        uint256 _backerAmountCoinbase = UtilsLib._mulPrec(builderRewardPercentage_, msg.value);
+        uint256 _backerAmountERC20 = UtilsLib._mulPrec(backerRewardPercentage_, amountERC20_);
+        uint256 _backerAmountCoinbase = UtilsLib._mulPrec(backerRewardPercentage_, msg.value);
         uint256 _timeUntilNextCycle = UtilsLib._calcTimeUntilNextCycle(cycleStart_, cycleDuration_, block.timestamp);
         _notifyRewardAmount(
             rewardToken, amountERC20_ - _backerAmountERC20, _backerAmountERC20, periodFinish_, _timeUntilNextCycle

--- a/test/BuilderRegistryRootstockCollective.t.sol
+++ b/test/BuilderRegistryRootstockCollective.t.sol
@@ -169,7 +169,7 @@ contract BuilderRegistryRootstockCollectiveTest is BaseTest {
     /**
      * SCENARIO: activateBuilder should revert if reward percentage is higher than 100
      */
-    function test_ActivateBuilderInvalidBuilderRewardPercentage() public {
+    function test_ActivateBuilderInvalidBackerRewardPercentage() public {
         // GIVEN a new builder
         address _newBuilder = makeAddr("newBuilder");
         // AND a kycApprover
@@ -177,7 +177,7 @@ contract BuilderRegistryRootstockCollectiveTest is BaseTest {
 
         // WHEN tries to activateBuilder
         //  THEN tx reverts because is not a valid reward percentage
-        vm.expectRevert(BuilderRegistryRootstockCollective.InvalidBuilderRewardPercentage.selector);
+        vm.expectRevert(BuilderRegistryRootstockCollective.InvalidBackerRewardPercentage.selector);
         backersManager.activateBuilder(_newBuilder, _newBuilder, 2 ether);
     }
 
@@ -353,13 +353,13 @@ contract BuilderRegistryRootstockCollectiveTest is BaseTest {
     /**
      * SCENARIO: permitBuilder should revert if reward percentage is higher than 100
      */
-    function test_PermitBuilderInvalidBuilderRewardPercentage() public {
+    function test_PermitBuilderInvalidBackerRewardPercentage() public {
         // GIVEN a revoked builder
         vm.startPrank(builder);
         backersManager.revokeBuilder();
         //  WHEN tries to permitBuilder with 200% of reward percentage
         //   THEN tx reverts because is not a valid reward percentage
-        vm.expectRevert(BuilderRegistryRootstockCollective.InvalidBuilderRewardPercentage.selector);
+        vm.expectRevert(BuilderRegistryRootstockCollective.InvalidBackerRewardPercentage.selector);
         backersManager.permitBuilder(2 ether);
     }
 

--- a/test/GaugeRootstockCollective.t.sol
+++ b/test/GaugeRootstockCollective.t.sol
@@ -186,9 +186,9 @@ contract GaugeRootstockCollectiveTest is BaseTest {
      * rewards variables are updated in the middle and at the end of the cycle
      */
     function test_NotifyRewardAmountWithStrategy() public {
-        // GIVEN a builder with 70% of reward percentage
+        // GIVEN a builder with 70% of reward percentage for backers
         vm.startPrank(builder);
-        backersManager.setBuilderRewardPercentage(0.7 ether);
+        backersManager.setBackerRewardPercentage(0.7 ether);
         skip(rewardPercentageCooldown);
 
         // AND 6 ether are allocated to alice
@@ -858,12 +858,12 @@ contract GaugeRootstockCollectiveTest is BaseTest {
      * SCENARIO: builder claim his rewards in another gauge
      */
     function test_ClaimBuilderWrongGauge() public {
-        // GIVEN a builder with 30% of reward percentage
+        // GIVEN a builder with 30% of reward percentage for backers
         vm.startPrank(builder);
-        backersManager.setBuilderRewardPercentage(0.3 ether);
-        // GIVEN a builder2 with 15% of reward percentage
+        backersManager.setBackerRewardPercentage(0.3 ether);
+        // GIVEN a builder2 with 15% of reward percentage for backers
         vm.startPrank(builder2);
-        backersManager.setBuilderRewardPercentage(0.15 ether);
+        backersManager.setBackerRewardPercentage(0.15 ether);
         skip(rewardPercentageCooldown);
         // AND alice allocates to gauge and gauge2
         vm.startPrank(alice);
@@ -898,9 +898,9 @@ contract GaugeRootstockCollectiveTest is BaseTest {
      * SCENARIO: builder claims his rewards at any time during the cycle receiving the total amount of rewards.
      */
     function test_ClaimBuilderRewardsBuilder() public {
-        // GIVEN a builder with 30% of reward percentage
+        // GIVEN a builder with 30% of reward percentage for backers
         vm.startPrank(builder);
-        backersManager.setBuilderRewardPercentage(0.3 ether);
+        backersManager.setBackerRewardPercentage(0.3 ether);
         skip(rewardPercentageCooldown);
         // AND alice allocates to gauge
         vm.startPrank(alice);
@@ -931,9 +931,9 @@ contract GaugeRootstockCollectiveTest is BaseTest {
      * SCENARIO: reward receiver claims his rewards at any time during the cycle receiving the total amount of rewards.
      */
     function test_ClaimBuilderRewardsRewardReceiver() public {
-        // GIVEN a builder2 with 30% of reward percentage
+        // GIVEN a builder2 with 30% of reward percentage for backers
         vm.startPrank(builder2);
-        backersManager.setBuilderRewardPercentage(0.3 ether);
+        backersManager.setBackerRewardPercentage(0.3 ether);
         skip(rewardPercentageCooldown);
         // AND alice allocates to gauge2
         vm.startPrank(alice);
@@ -975,9 +975,9 @@ contract GaugeRootstockCollectiveTest is BaseTest {
      * SCENARIO: there are 2 distributions in the same distribution window, builder claimS the rewards
      */
     function test_ClaimBuilderRewards2Distributions() public {
-        // GIVEN a builder with 30% of reward percentage
+        // GIVEN a builder with 30% of reward percentage for backers
         vm.startPrank(builder);
-        backersManager.setBuilderRewardPercentage(0.3 ether);
+        backersManager.setBackerRewardPercentage(0.3 ether);
         skip(rewardPercentageCooldown);
         // AND alice allocates to gauge
         vm.startPrank(alice);
@@ -1020,9 +1020,9 @@ contract GaugeRootstockCollectiveTest is BaseTest {
      * SCENARIO: there are 2 cycles, builder claims the rewards
      */
     function test_ClaimBuilderRewards2Cycles() public {
-        // GIVEN a builder with 30% of reward percentage
+        // GIVEN a builder with 30% of reward percentage for backers
         vm.startPrank(builder);
-        backersManager.setBuilderRewardPercentage(0.3 ether);
+        backersManager.setBackerRewardPercentage(0.3 ether);
         skip(rewardPercentageCooldown);
         // AND alice allocates to gauge
         vm.startPrank(alice);

--- a/test/MigrateBuilder.t.sol
+++ b/test/MigrateBuilder.t.sol
@@ -35,7 +35,7 @@ contract MigrateBuilderTest is BaseTest {
         _validateIsWhitelisted(_v1Builder01);
 
         // AND reward receiver and percentage are set correctly
-        (, uint64 next,) = backersManager.builderRewardPercentage(_v1Builder01);
+        (, uint64 next,) = backersManager.backerRewardPercentage(_v1Builder01);
         vm.assertEq(backersManager.builderRewardReceiver(_v1Builder01), _v1Builder01);
         vm.assertEq(next, _validRewardPercentage);
     }
@@ -132,8 +132,8 @@ contract MigrateBuilderTest is BaseTest {
         uint64 _invalidRewardPercentage = type(uint64).max;
 
         //  WHEN kyc approver attempts to migrate a builder with the invalid percentage
-        //   THEN the transaction reverts with InvalidBuilderRewardPercentage error
-        vm.expectRevert(BuilderRegistryRootstockCollective.InvalidBuilderRewardPercentage.selector);
+        //   THEN the transaction reverts with InvalidBackerRewardPercentage error
+        vm.expectRevert(BuilderRegistryRootstockCollective.InvalidBackerRewardPercentage.selector);
         vm.prank(kycApprover);
         backersManager.migrateBuilder(_v1Builder01, _v1Builder01, _invalidRewardPercentage);
     }

--- a/test/RevokeBuilder.t.sol
+++ b/test/RevokeBuilder.t.sol
@@ -126,8 +126,8 @@ contract RevokeBuilderTest is HaltedBuilderBehavior, ResumeBuilderBehavior {
         //    AND builder is revoked
         _initialState();
 
-        (uint64 _previous, uint64 _next, uint128 _cooldownEndTime) = backersManager.builderRewardPercentage(builder);
-        // THEN builder reward percentage cooldown end time is 2 weeks from now
+        (uint64 _previous, uint64 _next, uint128 _cooldownEndTime) = backersManager.backerRewardPercentage(builder);
+        // THEN backer reward percentage cooldown end time is 2 weeks from now
         assertEq(_cooldownEndTime, block.timestamp + 2 weeks);
 
         // AND cooldown time didn't end
@@ -136,19 +136,19 @@ contract RevokeBuilderTest is HaltedBuilderBehavior, ResumeBuilderBehavior {
         // WHEN gauge is permitted with a new reward percentage of 80%
         vm.startPrank(builder);
         backersManager.permitBuilder(0.8 ether);
-        (_previous, _next, _cooldownEndTime) = backersManager.builderRewardPercentage(builder);
-        // THEN previous builder reward percentage is 50%
+        (_previous, _next, _cooldownEndTime) = backersManager.backerRewardPercentage(builder);
+        // THEN previous backer reward percentage is 50%
         assertEq(_previous, 0.5 ether);
-        // THEN next builder reward percentage is 80%
+        // THEN next backer reward percentage is 80%
         assertEq(_next, 0.8 ether);
-        // THEN builder reward percentage cooldown didn't finish
+        // THEN backer reward percentage cooldown didn't finish
         assertGe(_cooldownEndTime, block.timestamp);
-        // THEN builder reward percentage to apply is 50%
+        // THEN backer reward percentage to apply is 50%
         assertEq(backersManager.getRewardPercentageToApply(builder), 0.5 ether);
 
         // THEN cooldown time ends
         skip(12 days);
-        // THEN builder reward percentage to apply is 80%
+        // THEN backer reward percentage to apply is 80%
         assertEq(backersManager.getRewardPercentageToApply(builder), 0.8 ether);
     }
 
@@ -163,8 +163,8 @@ contract RevokeBuilderTest is HaltedBuilderBehavior, ResumeBuilderBehavior {
         //    AND builder is revoked
         _initialState();
 
-        (uint64 _previous, uint64 _next, uint128 _cooldownEndTime) = backersManager.builderRewardPercentage(builder);
-        // THEN builder reward percentage cooldown end time is 2 weeks from now
+        (uint64 _previous, uint64 _next, uint128 _cooldownEndTime) = backersManager.backerRewardPercentage(builder);
+        // THEN backer reward percentage cooldown end time is 2 weeks from now
         assertEq(_cooldownEndTime, block.timestamp + 2 weeks);
 
         // AND cooldown time ends
@@ -176,14 +176,14 @@ contract RevokeBuilderTest is HaltedBuilderBehavior, ResumeBuilderBehavior {
         // WHEN gauge is permitted with a new reward percentage of 80%
         vm.startPrank(builder);
         backersManager.permitBuilder(0.8 ether);
-        (_previous, _next, _cooldownEndTime) = backersManager.builderRewardPercentage(builder);
-        // THEN previous builder reward percentage is 50%
+        (_previous, _next, _cooldownEndTime) = backersManager.backerRewardPercentage(builder);
+        // THEN previous backer reward percentage is 50%
         assertEq(_previous, 0.5 ether);
-        // THEN next builder reward percentage is 80%
+        // THEN next backer reward percentage is 80%
         assertEq(_next, 0.8 ether);
-        // THEN builder reward percentage cooldown finished
+        // THEN backer reward percentage cooldown finished
         assertLe(_cooldownEndTime, block.timestamp);
-        // THEN builder reward percentage to apply is 80%
+        // THEN backer reward percentage to apply is 80%
         assertEq(backersManager.getRewardPercentageToApply(builder), 0.8 ether);
     }
 }

--- a/test/SetBackerRewardPercentage.t.sol
+++ b/test/SetBackerRewardPercentage.t.sol
@@ -4,11 +4,11 @@ pragma solidity 0.8.20;
 import { BaseTest } from "./BaseTest.sol";
 import { BuilderRegistryRootstockCollective } from "../src/BuilderRegistryRootstockCollective.sol";
 
-contract setBuilderRewardPercentageTest is BaseTest {
+contract setBackerRewardPercentageTest is BaseTest {
     // -----------------------------
     // ----------- Events ----------
     // -----------------------------
-    event BuilderRewardPercentageUpdateScheduled(
+    event BackerRewardPercentageUpdateScheduled(
         address indexed builder_, uint256 rewardPercentage_, uint256 expiration_
     );
 
@@ -30,109 +30,109 @@ contract setBuilderRewardPercentageTest is BaseTest {
 
         // AND builder sets a new reward percentage of 10%
         vm.startPrank(builder);
-        backersManager.setBuilderRewardPercentage(0.1 ether);
+        backersManager.setBackerRewardPercentage(0.1 ether);
         vm.stopPrank();
     }
 
     /**
-     * SCENARIO: setBuilderRewardPercentage should revert if is not called by the builder
+     * SCENARIO: setBackerRewardPercentage should revert if is not called by the builder
      */
     function test_CallerIsNotABuilder() public {
         // GIVEN a whitelisted builder
-        //  WHEN calls setBuilderRewardPercentage
+        //  WHEN calls setBackerRewardPercentage
         //   THEN tx reverts because caller is not an operational builder
         vm.expectRevert(BuilderRegistryRootstockCollective.NotOperational.selector);
-        backersManager.setBuilderRewardPercentage(0.1 ether);
+        backersManager.setBackerRewardPercentage(0.1 ether);
     }
 
     /**
      * SCENARIO: Builder sets a new reward percentage
      */
-    function test_setBuilderRewardPercentage() public {
+    function test_setBackerRewardPercentage() public {
         // GIVEN a Whitelisted builder
-        //  WHEN builder calls setBuilderRewardPercentage
+        //  WHEN builder calls setBackerRewardPercentage
         vm.prank(builder);
-        //   THEN BuilderRewardPercentageUpdateScheduled event is emitted
+        //   THEN BackerRewardPercentageUpdateScheduled event is emitted
         vm.expectEmit();
-        emit BuilderRewardPercentageUpdateScheduled(builder, 0.1 ether, block.timestamp + 2 weeks);
-        backersManager.setBuilderRewardPercentage(0.1 ether);
+        emit BackerRewardPercentageUpdateScheduled(builder, 0.1 ether, block.timestamp + 2 weeks);
+        backersManager.setBackerRewardPercentage(0.1 ether);
 
-        (uint64 _previous, uint64 _next, uint128 _cooldownEndTime) = backersManager.builderRewardPercentage(builder);
-        // THEN previous builder reward percentage is 50%
+        (uint64 _previous, uint64 _next, uint128 _cooldownEndTime) = backersManager.backerRewardPercentage(builder);
+        // THEN previous backer reward percentage is 50%
         assertEq(_previous, 0.5 ether);
-        // THEN next builder reward percentage is 10%
+        // THEN next backer reward percentage is 10%
         assertEq(_next, 0.1 ether);
-        // THEN builder reward percentage cooldown end time is 2 weeks from now
+        // THEN backer reward percentage cooldown end time is 2 weeks from now
         assertEq(_cooldownEndTime, block.timestamp + 2 weeks);
-        // THEN builder reward percentage to apply is 50%
+        // THEN backer reward percentage to apply is 50%
         assertEq(backersManager.getRewardPercentageToApply(builder), 0.5 ether);
     }
 
     /**
      * SCENARIO: Builder sets a new reward percentage with the same value
      */
-    function test_setBuilderRewardPercentageSameValue() public {
-        // GIVEN a Whitelisted builder with 50% of reward percentage
-        //  WHEN builder calls setBuilderRewardPercentage again with 50%
+    function test_setBackerRewardPercentageSameValue() public {
+        // GIVEN a Whitelisted builder with 50% of reward percentage for backers
+        //  WHEN builder calls setBackerRewardPercentage again with 50%
         vm.prank(builder);
-        backersManager.setBuilderRewardPercentage(0.5 ether);
+        backersManager.setBackerRewardPercentage(0.5 ether);
 
-        (uint64 _previous, uint64 _next,) = backersManager.builderRewardPercentage(builder);
+        (uint64 _previous, uint64 _next,) = backersManager.backerRewardPercentage(builder);
         // THEN previous and next reward percentages are the same
         assertEq(_previous, _next);
-        // THEN builder reward percentage to apply is 50%
+        // THEN backer reward percentage to apply is 50%
         assertEq(backersManager.getRewardPercentageToApply(builder), 0.5 ether);
     }
 
     /**
-     * SCENARIO: setBuilderRewardPercentage reverts if it is not operational
+     * SCENARIO: setBackerRewardPercentage reverts if it is not operational
      */
-    function test_RevertsetBuilderRewardPercentageWrongStatus() public {
+    function test_RevertsetBackerRewardPercentageWrongStatus() public {
         // GIVEN a Paused builder
         vm.startPrank(kycApprover);
         backersManager.pauseBuilder(builder, "paused");
-        // WHEN tries to setBuilderRewardPercentage
+        // WHEN tries to setBackerRewardPercentage
         //  THEN tx reverts because is not operational
         vm.startPrank(builder);
         vm.expectRevert(BuilderRegistryRootstockCollective.NotOperational.selector);
-        backersManager.setBuilderRewardPercentage(0.1 ether);
+        backersManager.setBackerRewardPercentage(0.1 ether);
     }
 
     /**
-     * SCENARIO: setBuilderRewardPercentage should reverts if reward percentage is higher than 100
+     * SCENARIO: setBackerRewardPercentage should reverts if reward percentage is higher than 100
      */
-    function test_setBuilderRewardPercentageInvalidBuilderRewardPercentage() public {
+    function test_setBackerRewardPercentageInvalidBackerRewardPercentage() public {
         // GIVEN a Whitelisted builder
-        //  WHEN tries to setBuilderRewardPercentage
+        //  WHEN tries to setBackerRewardPercentage
         //   THEN tx reverts because is not a valid reward percentage
         vm.prank(builder);
-        vm.expectRevert(BuilderRegistryRootstockCollective.InvalidBuilderRewardPercentage.selector);
-        backersManager.setBuilderRewardPercentage(2 ether);
+        vm.expectRevert(BuilderRegistryRootstockCollective.InvalidBackerRewardPercentage.selector);
+        backersManager.setBackerRewardPercentage(2 ether);
     }
 
     /**
      * SCENARIO: Builder sets a new reward percentage again before it is applied and needs to wait the cooldown again
      */
-    function test_setBuilderRewardPercentageTwiceBeforeCooldown() public {
+    function test_setBackerRewardPercentageTwiceBeforeCooldown() public {
         // GIVEN alice and bob allocate to builder and builder2
         //  AND builder sets a new reward percentage of 10%
         _initialState();
 
-        (uint64 _previous, uint64 _next, uint128 _cooldownEndTime) = backersManager.builderRewardPercentage(builder);
+        (uint64 _previous, uint64 _next, uint128 _cooldownEndTime) = backersManager.backerRewardPercentage(builder);
         // AND cooldown time didn't end
         vm.warp(_cooldownEndTime - 1);
 
         // AND builder sets the reward percentage to 80%
         vm.prank(builder);
-        backersManager.setBuilderRewardPercentage(0.8 ether);
-        (_previous, _next, _cooldownEndTime) = backersManager.builderRewardPercentage(builder);
-        // THEN previous builder reward percentage is 50%
+        backersManager.setBackerRewardPercentage(0.8 ether);
+        (_previous, _next, _cooldownEndTime) = backersManager.backerRewardPercentage(builder);
+        // THEN previous backer reward percentage is 50%
         assertEq(_previous, 0.5 ether);
-        // THEN next builder reward percentage is 80%
+        // THEN next backer reward percentage is 80%
         assertEq(_next, 0.8 ether);
-        // THEN builder reward percentage cooldown end time is 2 weeks from now
+        // THEN backer reward percentage cooldown end time is 2 weeks from now
         assertEq(_cooldownEndTime, block.timestamp + 2 weeks);
-        // THEN builder reward percentage to apply is 50%
+        // THEN backer reward percentage to apply is 50%
         assertEq(backersManager.getRewardPercentageToApply(builder), 0.5 ether);
 
         // AND 100 rewardToken and 10 coinbase are distributed
@@ -155,9 +155,9 @@ contract setBuilderRewardPercentageTest is BaseTest {
         assertApproxEqAbs(_clearCoinbaseBalance(alice), 0.625 ether, 100);
 
         // AND cooldown time ends
-        (_previous, _next, _cooldownEndTime) = backersManager.builderRewardPercentage(builder);
+        (_previous, _next, _cooldownEndTime) = backersManager.backerRewardPercentage(builder);
         vm.warp(_cooldownEndTime);
-        // THEN builder reward percentage to apply is 80%
+        // THEN backer reward percentage to apply is 80%
         assertEq(backersManager.getRewardPercentageToApply(builder), 0.8 ether);
         // AND 100 rewardToken and 10 coinbase are distributed
         _distribute(100 ether, 10 ether);
@@ -182,32 +182,32 @@ contract setBuilderRewardPercentageTest is BaseTest {
     /**
      * SCENARIO: Builder sets a new reward percentage again after cooldown and previous one it is applied
      */
-    function test_setBuilderRewardPercentageTwiceAfterCooldown() public {
+    function test_setBackerRewardPercentageTwiceAfterCooldown() public {
         // GIVEN alice and bob allocate to builder and builder2
         //  AND builder sets a new reward percentage of 10%
         _initialState();
 
         // AND cooldown time ends
-        (uint64 _previous, uint64 _next, uint128 _cooldownEndTime) = backersManager.builderRewardPercentage(builder);
+        (uint64 _previous, uint64 _next, uint128 _cooldownEndTime) = backersManager.backerRewardPercentage(builder);
         vm.warp(_cooldownEndTime);
-        // THEN builder reward percentage to apply is 10%
+        // THEN backer reward percentage to apply is 10%
         assertEq(backersManager.getRewardPercentageToApply(builder), 0.1 ether);
         // AND builder sets the reward percentage to 80%
         vm.prank(builder);
-        backersManager.setBuilderRewardPercentage(0.8 ether);
-        // THEN builderRewardPercentageExpiration is 2 weeks from now
-        (_previous, _next, _cooldownEndTime) = backersManager.builderRewardPercentage(builder);
+        backersManager.setBackerRewardPercentage(0.8 ether);
+        // THEN backerRewardPercentageExpiration is 2 weeks from now
+        (_previous, _next, _cooldownEndTime) = backersManager.backerRewardPercentage(builder);
         assertEq(_cooldownEndTime, block.timestamp + 2 weeks);
 
         // AND 100 rewardToken and 10 coinbase are distributed
         _distribute(100 ether, 10 ether);
 
-        (_previous, _next, _cooldownEndTime) = backersManager.builderRewardPercentage(builder);
-        // THEN previous builder reward percentage is 10%
+        (_previous, _next, _cooldownEndTime) = backersManager.backerRewardPercentage(builder);
+        // THEN previous backer reward percentage is 10%
         assertEq(_previous, 0.1 ether);
-        // THEN next builder reward percentage is 80%
+        // THEN next backer reward percentage is 80%
         assertEq(_next, 0.8 ether);
-        // THEN builder reward percentage to apply is still 10%
+        // THEN backer reward percentage to apply is still 10%
         assertEq(backersManager.getRewardPercentageToApply(builder), 0.1 ether);
 
         // WHEN builder claim rewards
@@ -230,14 +230,14 @@ contract setBuilderRewardPercentageTest is BaseTest {
     /**
      * SCENARIO: Builder sets a new reward percentage and there are 2 distributions with the new one
      */
-    function test_BuilderRewardPercentageUpdate() public {
+    function test_BackerRewardPercentageUpdate() public {
         // GIVEN alice and bob allocate to builder and builder2
         //  AND builder sets a new reward percentage of 10%
         _initialState();
         // AND cooldown time ends
-        (,, uint128 _cooldownEndTime) = backersManager.builderRewardPercentage(builder);
+        (,, uint128 _cooldownEndTime) = backersManager.backerRewardPercentage(builder);
         vm.warp(_cooldownEndTime);
-        // THEN builder reward percentage to apply is 10%
+        // THEN backer reward percentage to apply is 10%
         assertEq(backersManager.getRewardPercentageToApply(builder), 0.1 ether);
         // AND 100 rewardToken and 10 coinbase are distributed
         _distribute(100 ether, 10 ether);


### PR DESCRIPTION
## What

- In `BuilderRegistry` smart contract, there is a variable named `builderRewardPercentage` which does not represent what the names try to represent, we are renaming it to `backerRewardPercentage` to align with the whitepaper and align what it represents. 

## Refs

- [Task](https://rsklabs.atlassian.net/browse/TOK-485) 
