### PR TITLE
[TOK-492] fix: collective rewards not beinig initialized on deploy

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -84,6 +84,7 @@ contract Deploy is Broadcaster, OutputWriter {
         );
         saveWithProxy("BackersManagerRootstockCollective", address(_backersManagerImpl), address(_backersManagerProxy));
 
+        vm.broadcast();
         _rewardDistributorProxy.initializeCollectiveRewardsAddresses(address(_backersManagerProxy));
     }
 }


### PR DESCRIPTION
## What

Adds the previous missing `broadcast()` to actually sign and bradcast the Tx to the network

## Why

Collective rewards not being initialized on deployment with function `initializeCollectiveRewardsAddresses`, the call was there, but the Tx wasn't.

## Testing

Deploy on testnet and verify that now the contract is initialized with backers address.

## Refs

https://rsklabs.atlassian.net/browse/TOK-492
https://book.getfoundry.sh/cheatcodes/broadcast
