### PR TITLE
Relax testing solhint rules

### DIFF
--- a/.solhint.test.json
+++ b/.solhint.test.json
@@ -14,6 +14,8 @@
     "bim/private-vars-leading-underscore-lib": "error",
     "bim/func-return-param-name-trailing-underscore": "error",
     "func-name-mixedcase": "off",
-    "foundry-test-functions": ["warn", ["setUp"]]
+    "foundry-test-functions": ["warn", ["setUp"]],
+    "no-empty-blocks": "off",
+    "one-contract-per-file": "off"
   }
 }

--- a/test/SetBackerRewardPercentage.t.sol
+++ b/test/SetBackerRewardPercentage.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.20;
 import { BaseTest } from "./BaseTest.sol";
 import { BuilderRegistryRootstockCollective } from "../src/BuilderRegistryRootstockCollective.sol";
 
-contract setBackerRewardPercentageTest is BaseTest {
+contract SetBackerRewardPercentageTest is BaseTest {
     // -----------------------------
     // ----------- Events ----------
     // -----------------------------

--- a/test/governance/GovernanceManagerRootstockCollective.t.sol
+++ b/test/governance/GovernanceManagerRootstockCollective.t.sol
@@ -232,6 +232,7 @@ contract GovernanceManagerRootstockCollectiveTest is BaseTest {
 contract SampleChangeContract is IChangeContractRootstockCollective {
     bool public executed = false;
 
+    // solhint-disable-next-line foundry-test-functions
     function execute() external {
         executed = true;
     }


### PR DESCRIPTION
## What

Turns off two lint rules that are not that important on testing context:
- "no-empty-blocks": "off",
-  "one-contract-per-file": "

And fixes/addresses same other trivial warning.

## Why

To clear the shell output from unnecessary warnings.

## Testing

`bun run lint`
