### PR TITLE
Add dust tolerance on invariants

### DIFF
--- a/test/invariant/BaseInvariants.sol
+++ b/test/invariant/BaseInvariants.sol
@@ -10,6 +10,8 @@ import { DistributionHandler } from "./handlers/DistributionHandler.sol";
 import { IncentivizeHandler } from "./handlers/IncentivizeHandler.sol";
 
 contract BaseInvariants is BaseTest {
+    uint256 constant DUST = 10_000;
+
     TimeManager public timeManager;
     BuilderHandler public builderHandler;
     AllocateHandler public allocateHandler;

--- a/test/invariant/RewardInvariants.t.sol
+++ b/test/invariant/RewardInvariants.t.sol
@@ -43,19 +43,18 @@ contract RewardInvariants is BaseInvariants {
             _totalGaugesBalances + _backersManagerBalance + _totalBuilderBalances + _totalBackersBalances
         );
 
-        assertLe(_backersManagerBalance, 10_000);
+        assertLe(_backersManagerBalance, DUST);
 
         for (uint256 i = 0; i < gaugesArray.length; i++) {
+            uint256 _gaugeBalance = rewardToken.balanceOf(address(gaugesArray[i]));
+            uint256 _gaugeAccountedBalance;
             if (gaugesArray[i].totalAllocation() > 0) {
-                uint256 _gaugeBalance = rewardToken.balanceOf(address(gaugesArray[i]))
-                    - gaugesArray[i].rewardMissing(address(rewardToken)) / 10 ** 18;
-                assertLe(_gaugeBalance, 10_000);
+                _gaugeAccountedBalance = gaugesArray[i].rewardMissing(address(rewardToken)) / 10 ** 18;
             } else {
-                assertEq(
-                    rewardToken.balanceOf(address(gaugesArray[i])),
-                    incentivizeHandler.rewardTokenIncentives(gaugesArray[i])
-                );
+                _gaugeAccountedBalance = incentivizeHandler.rewardTokenIncentives(gaugesArray[i]);
             }
+            // There might be dust from previous cycles
+            assertLe(_gaugeBalance - _gaugeAccountedBalance, DUST);
         }
     }
 }


### PR DESCRIPTION
## What

Introduce dust tolerance to gauge balance on invariant tests. 

## Why

As the deep run might include several cycle distributions, there might be duut left from previous ones.  

## Testing

let it :fire: those :computer: :computer: 
