### PR TITLE
TOK-480: add comment on top of rewardToken

### DIFF
--- a/src/BackersManagerRootstockCollective.sol
+++ b/src/BackersManagerRootstockCollective.sol
@@ -93,7 +93,7 @@ contract BackersManagerRootstockCollective is
     /**
      * @notice contract initializer
      * @param governanceManager_ contract with permissioned roles
-     * @param rewardToken_ address of the token rewarded to builder and voters
+     * @param rewardToken_ address of the token rewarded to builder and voters, only standard ERC20 MUST be used
      * @param stakingToken_ address of the staking token for builder and voters
      * @param gaugeFactory_ address of the GaugeFactoryRootstockCollective contract
      * @param rewardDistributor_ address of the rewardDistributor contract

--- a/src/gauge/GaugeRootstockCollective.sol
+++ b/src/gauge/GaugeRootstockCollective.sol
@@ -99,7 +99,7 @@ contract GaugeRootstockCollective is ReentrancyGuardUpgradeable {
 
     /**
      * @notice contract initializer
-     * @param rewardToken_ address of the token rewarded to builder and voters
+     * @param rewardToken_ address of the token rewarded to builder and voters, only standard ERC20 MUST be used
      * @param backersManager_ address of the BackersManagerRootstockCollective contract
      */
     function initialize(address rewardToken_, address backersManager_) external initializer {


### PR DESCRIPTION
## What

- It is required to mention that only standard ERC20 tokens must be used as reward Token

## Why

- The external auditors have supposed a scenario where a non-standard token could break our rewards logic
