### PR TITLE
Code reorg

### DIFF
--- a/script/BackersManagerRootstockCollective.s.sol
+++ b/script/BackersManagerRootstockCollective.s.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.20;
 
 import { Broadcaster } from "script/script_utils/Broadcaster.s.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import { BackersManagerRootstockCollective } from "src/BackersManagerRootstockCollective.sol";
+import { BackersManagerRootstockCollective } from "src/backersManager/BackersManagerRootstockCollective.sol";
 import { IGovernanceManagerRootstockCollective } from "../src/interfaces/IGovernanceManagerRootstockCollective.sol";
 
 contract Deploy is Broadcaster {

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.20;
 
 import { Broadcaster } from "script/script_utils/Broadcaster.s.sol";
 import { OutputWriter } from "script/script_utils/OutputWriter.s.sol";
-import { BackersManagerRootstockCollective } from "src/BackersManagerRootstockCollective.sol";
+import { BackersManagerRootstockCollective } from "src/backersManager/BackersManagerRootstockCollective.sol";
 import { Deploy as BackersManagerRootstockCollectiveDeployer } from "script/BackersManagerRootstockCollective.s.sol";
 import { GaugeBeaconRootstockCollective } from "src/gauge/GaugeBeaconRootstockCollective.sol";
 import { Deploy as GaugeBeaconRootstockCollectiveDeployer } from "script/gauge/GaugeBeaconRootstockCollective.s.sol";

--- a/src/CycleTimeKeeperRootstockCollective.sol
+++ b/src/CycleTimeKeeperRootstockCollective.sol
@@ -3,10 +3,14 @@ pragma solidity 0.8.20;
 
 import { UpgradeableRootstockCollective } from "./governance/UpgradeableRootstockCollective.sol";
 import { UtilsLib } from "./libraries/UtilsLib.sol";
+import { IBackersManagerRootstockCollective } from "./interfaces/IBackersManagerRootstockCollective.sol";
 import { IGovernanceManagerRootstockCollective } from "./interfaces/IGovernanceManagerRootstockCollective.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
-abstract contract CycleTimeKeeperRootstockCollective is UpgradeableRootstockCollective {
+abstract contract CycleTimeKeeperRootstockCollective is
+    IBackersManagerRootstockCollective,
+    UpgradeableRootstockCollective
+{
     error NotValidChangerOrFoundation();
 
     modifier onlyValidChangerOrFoundation() {

--- a/src/RewardDistributorRootstockCollective.sol
+++ b/src/RewardDistributorRootstockCollective.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.20;
 
 import { UpgradeableRootstockCollective } from "./governance/UpgradeableRootstockCollective.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { BackersManagerRootstockCollective } from "./BackersManagerRootstockCollective.sol";
+import { BackersManagerRootstockCollective } from "./backersManager/BackersManagerRootstockCollective.sol";
 import { IGovernanceManagerRootstockCollective } from "./interfaces/IGovernanceManagerRootstockCollective.sol";
 
 /**

--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -4,11 +4,12 @@ pragma solidity 0.8.20;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
-import { GaugeRootstockCollective } from "./gauge/GaugeRootstockCollective.sol";
+import { GaugeRootstockCollective } from "../gauge/GaugeRootstockCollective.sol";
 import { BuilderRegistryRootstockCollective } from "./BuilderRegistryRootstockCollective.sol";
-import { ICollectiveRewardsCheckRootstockCollective } from "./interfaces/ICollectiveRewardsCheckRootstockCollective.sol";
-import { UtilsLib } from "./libraries/UtilsLib.sol";
-import { IGovernanceManagerRootstockCollective } from "./interfaces/IGovernanceManagerRootstockCollective.sol";
+import { ICollectiveRewardsCheckRootstockCollective } from
+    "../interfaces/ICollectiveRewardsCheckRootstockCollective.sol";
+import { UtilsLib } from "../libraries/UtilsLib.sol";
+import { IGovernanceManagerRootstockCollective } from "../interfaces/IGovernanceManagerRootstockCollective.sol";
 
 /**
  * @title BackersManagerRootstockCollective

--- a/src/backersManager/BuilderRegistryRootstockCollective.sol
+++ b/src/backersManager/BuilderRegistryRootstockCollective.sol
@@ -2,12 +2,12 @@
 pragma solidity 0.8.20;
 
 import { CycleTimeKeeperRootstockCollective } from "./CycleTimeKeeperRootstockCollective.sol";
-import { UtilsLib } from "./libraries/UtilsLib.sol";
+import { UtilsLib } from "../libraries/UtilsLib.sol";
 import { ERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import { GaugeRootstockCollective } from "./gauge/GaugeRootstockCollective.sol";
-import { GaugeFactoryRootstockCollective } from "./gauge/GaugeFactoryRootstockCollective.sol";
-import { IGovernanceManagerRootstockCollective } from "./interfaces/IGovernanceManagerRootstockCollective.sol";
+import { GaugeRootstockCollective } from "../gauge/GaugeRootstockCollective.sol";
+import { GaugeFactoryRootstockCollective } from "../gauge/GaugeFactoryRootstockCollective.sol";
+import { IGovernanceManagerRootstockCollective } from "../interfaces/IGovernanceManagerRootstockCollective.sol";
 
 /**
  * @title BuilderRegistryRootstockCollective

--- a/src/backersManager/CycleTimeKeeperRootstockCollective.sol
+++ b/src/backersManager/CycleTimeKeeperRootstockCollective.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import { UpgradeableRootstockCollective } from "./governance/UpgradeableRootstockCollective.sol";
-import { UtilsLib } from "./libraries/UtilsLib.sol";
-import { IBackersManagerRootstockCollective } from "./interfaces/IBackersManagerRootstockCollective.sol";
-import { IGovernanceManagerRootstockCollective } from "./interfaces/IGovernanceManagerRootstockCollective.sol";
+import { UpgradeableRootstockCollective } from "../governance/UpgradeableRootstockCollective.sol";
+import { UtilsLib } from "../libraries/UtilsLib.sol";
+import { IBackersManagerRootstockCollective } from "../interfaces/IBackersManagerRootstockCollective.sol";
+import { IGovernanceManagerRootstockCollective } from "../interfaces/IGovernanceManagerRootstockCollective.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 abstract contract CycleTimeKeeperRootstockCollective is

--- a/src/gauge/GaugeRootstockCollective.sol
+++ b/src/gauge/GaugeRootstockCollective.sol
@@ -279,7 +279,7 @@ contract GaugeRootstockCollective is ReentrancyGuardUpgradeable {
      *  address(uint160(uint256(keccak256("COINBASE_ADDRESS")))) is used for coinbase address
      */
     function claimBuilderReward(address rewardToken_) public {
-        address _builder = backersManager.gaugeToBuilder(address(this));
+        address _builder = backersManager.gaugeToBuilder(this);
         address _rewardReceiver = backersManager.builderRewardReceiver(_builder);
         if (backersManager.isBuilderPaused(_builder)) revert BuilderRewardsLocked();
         if (msg.sender != _builder && msg.sender != _rewardReceiver) revert NotAuthorized();

--- a/src/governance/changerTemplates/CommunityApproveBuilderChangerTemplateRootstockCollective.sol
+++ b/src/governance/changerTemplates/CommunityApproveBuilderChangerTemplateRootstockCollective.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.20;
 
 import { IChangeContractRootstockCollective } from "../../interfaces/IChangeContractRootstockCollective.sol";
-import { BackersManagerRootstockCollective } from "../../BackersManagerRootstockCollective.sol";
+import { BackersManagerRootstockCollective } from "../../backersManager/BackersManagerRootstockCollective.sol";
 import { GaugeRootstockCollective } from "../../gauge/GaugeRootstockCollective.sol";
 
 /**

--- a/src/interfaces/IBackersManagerRootstockCollective.sol
+++ b/src/interfaces/IBackersManagerRootstockCollective.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
+import { GaugeRootstockCollective } from "../gauge/GaugeRootstockCollective.sol";
+
 /**
  * @title IBackersManagerRootstockCollective
  */
@@ -13,7 +15,7 @@ interface IBackersManagerRootstockCollective {
     /**
      * @notice returns builder address for a given gauge
      */
-    function gaugeToBuilder(address gauge_) external view returns (address builder_);
+    function gaugeToBuilder(GaugeRootstockCollective gauge_) external view returns (address builder_);
 
     /**
      * @notice returns rewards receiver for a given builder

--- a/test/BackersManagerRootstockCollective.t.sol
+++ b/test/BackersManagerRootstockCollective.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.20;
 
 import { stdStorage, StdStorage, stdError } from "forge-std/src/Test.sol";
 import { BaseTest, BackersManagerRootstockCollective, GaugeRootstockCollective } from "./BaseTest.sol";
-import { BuilderRegistryRootstockCollective } from "../src/BuilderRegistryRootstockCollective.sol";
+import { BuilderRegistryRootstockCollective } from "../src/backersManager/BuilderRegistryRootstockCollective.sol";
 import { UtilsLib } from "../src/libraries/UtilsLib.sol";
 
 contract BackersManagerRootstockCollectiveTest is BaseTest {

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -14,7 +14,7 @@ import { StakingTokenMock } from "./mock/StakingTokenMock.sol";
 import { GaugeBeaconRootstockCollective } from "src/gauge/GaugeBeaconRootstockCollective.sol";
 import { GaugeFactoryRootstockCollective } from "src/gauge/GaugeFactoryRootstockCollective.sol";
 import { GaugeRootstockCollective } from "src/gauge/GaugeRootstockCollective.sol";
-import { BackersManagerRootstockCollective } from "src/BackersManagerRootstockCollective.sol";
+import { BackersManagerRootstockCollective } from "src/backersManager/BackersManagerRootstockCollective.sol";
 import { RewardDistributorRootstockCollective } from "src/RewardDistributorRootstockCollective.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { Deploy as GovernanceManagerRootstockCollectiveDeployer } from

--- a/test/BuilderRegistryRootstockCollective.t.sol
+++ b/test/BuilderRegistryRootstockCollective.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.20;
 
 import { BaseTest, GaugeRootstockCollective } from "./BaseTest.sol";
-import { BuilderRegistryRootstockCollective } from "../src/BuilderRegistryRootstockCollective.sol";
+import { BuilderRegistryRootstockCollective } from "../src/backersManager/BuilderRegistryRootstockCollective.sol";
 import { IGovernanceManagerRootstockCollective } from "src/interfaces/IGovernanceManagerRootstockCollective.sol";
 
 contract BuilderRegistryRootstockCollectiveTest is BaseTest {

--- a/test/MigrateBuilder.t.sol
+++ b/test/MigrateBuilder.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.20;
 
 import { BaseTest } from "./BaseTest.sol";
-import { BuilderRegistryRootstockCollective } from "../src/BuilderRegistryRootstockCollective.sol";
+import { BuilderRegistryRootstockCollective } from "../src/backersManager/BuilderRegistryRootstockCollective.sol";
 import { IGovernanceManagerRootstockCollective } from "src/interfaces/IGovernanceManagerRootstockCollective.sol";
 
 contract MigrateBuilderTest is BaseTest {

--- a/test/SetBackerRewardPercentage.t.sol
+++ b/test/SetBackerRewardPercentage.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.20;
 
 import { BaseTest } from "./BaseTest.sol";
-import { BuilderRegistryRootstockCollective } from "../src/BuilderRegistryRootstockCollective.sol";
+import { BuilderRegistryRootstockCollective } from "../src/backersManager/BuilderRegistryRootstockCollective.sol";
 
 contract SetBackerRewardPercentageTest is BaseTest {
     // -----------------------------

--- a/test/SetBuilderRewardReceiver.t.sol
+++ b/test/SetBuilderRewardReceiver.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.20;
 
 import { BaseTest } from "./BaseTest.sol";
-import { BuilderRegistryRootstockCollective } from "../src/BuilderRegistryRootstockCollective.sol";
+import { BuilderRegistryRootstockCollective } from "../src/backersManager/BuilderRegistryRootstockCollective.sol";
 import { IGovernanceManagerRootstockCollective } from "src/interfaces/IGovernanceManagerRootstockCollective.sol";
 
 contract SetBuilderRewardReceiverTest is BaseTest {

--- a/test/SetCycleDuration.t.sol
+++ b/test/SetCycleDuration.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.20;
 
 import { BaseTest } from "./BaseTest.sol";
-import { CycleTimeKeeperRootstockCollective } from "../src/CycleTimeKeeperRootstockCollective.sol";
+import { CycleTimeKeeperRootstockCollective } from "../src/backersManager/CycleTimeKeeperRootstockCollective.sol";
 import { UtilsLib } from "../src/libraries/UtilsLib.sol";
 
 contract SetCycleDurationTest is BaseTest {

--- a/test/SetDistributionDuration.t.sol
+++ b/test/SetDistributionDuration.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.20;
 
 import { BaseTest } from "./BaseTest.sol";
-import { CycleTimeKeeperRootstockCollective } from "../src/CycleTimeKeeperRootstockCollective.sol";
+import { CycleTimeKeeperRootstockCollective } from "../src/backersManager/CycleTimeKeeperRootstockCollective.sol";
 import { IGovernanceManagerRootstockCollective } from "src/interfaces/IGovernanceManagerRootstockCollective.sol";
 
 contract SetDistributionDurationTest is BaseTest {

--- a/test/invariant/handlers/BaseHandler.sol
+++ b/test/invariant/handlers/BaseHandler.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.20;
 import { Test } from "forge-std/src/Test.sol";
 import { BaseTest } from "../../BaseTest.sol";
 import { TimeManager } from "./TimeManager.sol";
-import { BackersManagerRootstockCollective } from "src/BackersManagerRootstockCollective.sol";
+import { BackersManagerRootstockCollective } from "src/backersManager/BackersManagerRootstockCollective.sol";
 
 contract BaseHandler is Test {
     BaseTest public baseTest;

--- a/test/mock/UpgradesMocks.sol
+++ b/test/mock/UpgradesMocks.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import { BackersManagerRootstockCollective } from "../../src/BackersManagerRootstockCollective.sol";
+import { BackersManagerRootstockCollective } from "../../src/backersManager/BackersManagerRootstockCollective.sol";
 import { RewardDistributorRootstockCollective } from "../../src/RewardDistributorRootstockCollective.sol";
 import { GaugeRootstockCollective } from "src/gauge/GaugeRootstockCollective.sol";
 import { GovernanceManagerRootstockCollective } from "src/governance/GovernanceManagerRootstockCollective.sol";


### PR DESCRIPTION
## What

- Makes BackerManager inherit from Interface
- Moves all BackerManager related contract files to `backerManager` folder

## Why

- makes de code more consistence and clear

## Testing

- all test should pass

## Refs

