### PR TITLE
TOK-568: allow backer rewards opt out

### DIFF
--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -38,9 +38,8 @@ contract BackersManagerRootstockCollective is
     error NoGaugesForDistribution();
     error NotAuthorized();
     error BackerOptedOutRewards();
-    error AlreadyOptedOutRewards();
     error AlreadyOptedInRewards();
-    error OptOutWithAllocations();
+    error BackerHasAllocations();
 
     // -----------------------------
     // ----------- Events ----------
@@ -200,7 +199,7 @@ contract BackersManagerRootstockCollective is
     )
         external
         notInDistributionPeriod
-        onlyOptedInBacker(msg.sender)
+        onlyOptedInBacker
     {
         (uint256 _newBackerTotalAllocation, uint256 _newTotalPotentialReward) = _allocate(
             gauge_,
@@ -227,7 +226,7 @@ contract BackersManagerRootstockCollective is
     )
         external
         notInDistributionPeriod
-        onlyOptedInBacker(msg.sender)
+        onlyOptedInBacker
     {
         uint256 _length = gauges_.length;
         if (_length != allocations_.length) revert UnequalLengths();
@@ -347,10 +346,10 @@ contract BackersManagerRootstockCollective is
      */
     function optOutRewards(address backer_) external onlyBackerOrFoundation(backer_) {
         if (backerTotalAllocation[backer_] != 0) {
-            revert OptOutWithAllocations();
+            revert BackerHasAllocations();
         }
         if (rewardsOptedOut[backer_]) {
-            revert AlreadyOptedOutRewards();
+            revert BackerOptedOutRewards();
         }
         rewardsOptedOut[backer_] = true;
         emit BackerRewardsOptedOut(backer_);

--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -67,8 +67,8 @@ contract BackersManagerRootstockCollective is
         _;
     }
 
-    modifier onlyBackerOrFoundation(address account_) {
-        if (msg.sender != account_ && msg.sender != governanceManager.foundationTreasury()) {
+    modifier onlyBackerOrKycApprover(address account_) {
+        if (msg.sender != account_ && msg.sender != governanceManager.kycApprover()) {
             revert NotAuthorized();
         }
         _;
@@ -344,7 +344,7 @@ contract BackersManagerRootstockCollective is
      *         and claiming rewards in the future.
      *         This action can only be performed by the backer themselves or by the foundation.
      */
-    function optOutRewards(address backer_) external onlyBackerOrFoundation(backer_) {
+    function optOutRewards(address backer_) external onlyBackerOrKycApprover(backer_) {
         if (backerTotalAllocation[backer_] != 0) {
             revert BackerHasAllocations();
         }
@@ -360,7 +360,7 @@ contract BackersManagerRootstockCollective is
      *         Backers are opted in by default; only those who have opted out can choose to opt in again.
      *         This action can be performed only by the backer themselves or by the foundation.
      */
-    function optInRewards(address backer_) external onlyBackerOrFoundation(backer_) {
+    function optInRewards(address backer_) external onlyBackerOrKycApprover(backer_) {
         if (!rewardsOptedOut[backer_]) {
             revert AlreadyOptedInRewards();
         }

--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -81,8 +81,8 @@ contract BackersManagerRootstockCollective is
         _;
     }
 
-    modifier onlyOptedInBacker(address account_) {
-        if (rewardsOptedOut[account_]) {
+    modifier onlyOptedInBacker() {
+        if (rewardsOptedOut[msg.sender]) {
             revert BackerOptedOutRewards();
         }
         _;

--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -37,6 +37,10 @@ contract BackersManagerRootstockCollective is
     error PositiveAllocationOnHaltedGauge();
     error NoGaugesForDistribution();
     error NotAuthorized();
+    error BackerOptedOutRewards();
+    error AlreadyOptedOutRewards();
+    error AlreadyOptedInRewards();
+    error OptOutWithAllocations();
 
     // -----------------------------
     // ----------- Events ----------
@@ -46,6 +50,8 @@ contract BackersManagerRootstockCollective is
     event RewardDistributionStarted(address indexed sender_);
     event RewardDistributed(address indexed sender_);
     event RewardDistributionFinished(address indexed sender_);
+    event BackerRewardsOptedOut(address indexed backer_);
+    event BackerRewardsOptedIn(address indexed backer_);
 
     // -----------------------------
     // --------- Modifiers ---------
@@ -62,9 +68,23 @@ contract BackersManagerRootstockCollective is
         _;
     }
 
+    modifier onlyBackerOrFoundation(address account_) {
+        if (msg.sender != account_ && msg.sender != governanceManager.foundationTreasury()) {
+            revert NotAuthorized();
+        }
+        _;
+    }
+
     modifier onlyBuilderRegistry() {
         if (msg.sender != address(builderRegistry)) {
             revert NotAuthorized();
+        }
+        _;
+    }
+
+    modifier onlyOptedInBacker(address account_) {
+        if (rewardsOptedOut[account_]) {
+            revert BackerOptedOutRewards();
         }
         _;
     }
@@ -96,6 +116,8 @@ contract BackersManagerRootstockCollective is
     mapping(address backer => uint256 allocation) public backerTotalAllocation;
     /// @notice address of the builder registry contract
     BuilderRegistryRootstockCollective public builderRegistry;
+    /// @notice Tracks whether a backer has opted out from rewards, disabling the allocation to builders if true
+    mapping(address backer => bool hasOptedOut) public rewardsOptedOut;
 
     // -----------------------------
     // ------- Initializer ---------
@@ -172,7 +194,14 @@ contract BackersManagerRootstockCollective is
      * @param gauge_ address of the gauge where the votes will be allocated
      * @param allocation_ amount of votes to allocate
      */
-    function allocate(GaugeRootstockCollective gauge_, uint256 allocation_) external notInDistributionPeriod {
+    function allocate(
+        GaugeRootstockCollective gauge_,
+        uint256 allocation_
+    )
+        external
+        notInDistributionPeriod
+        onlyOptedInBacker(msg.sender)
+    {
         (uint256 _newBackerTotalAllocation, uint256 _newTotalPotentialReward) = _allocate(
             gauge_,
             allocation_,
@@ -198,6 +227,7 @@ contract BackersManagerRootstockCollective is
     )
         external
         notInDistributionPeriod
+        onlyOptedInBacker(msg.sender)
     {
         uint256 _length = gauges_.length;
         if (_length != allocations_.length) revert UnequalLengths();
@@ -308,6 +338,35 @@ contract BackersManagerRootstockCollective is
             return builderRegistry.haltedGaugeLastPeriodFinish(GaugeRootstockCollective(msg.sender));
         }
         return _periodFinish;
+    }
+
+    /**
+     * @notice Allows a backer to opt out of rewards, preventing them from allocating votes
+     *         and claiming rewards in the future.
+     *         This action can only be performed by the backer themselves or by the foundation.
+     */
+    function optOutRewards(address backer_) external onlyBackerOrFoundation(backer_) {
+        if (backerTotalAllocation[backer_] != 0) {
+            revert OptOutWithAllocations();
+        }
+        if (rewardsOptedOut[backer_]) {
+            revert AlreadyOptedOutRewards();
+        }
+        rewardsOptedOut[backer_] = true;
+        emit BackerRewardsOptedOut(backer_);
+    }
+
+    /**
+     * @notice Enables a backer to opt in for rewards, allowing them to allocate votes and claim rewards.
+     *         Backers are opted in by default; only those who have opted out can choose to opt in again.
+     *         This action can be performed only by the backer themselves or by the foundation.
+     */
+    function optInRewards(address backer_) external onlyBackerOrFoundation(backer_) {
+        if (!rewardsOptedOut[backer_]) {
+            revert AlreadyOptedInRewards();
+        }
+        rewardsOptedOut[backer_] = false;
+        emit BackerRewardsOptedIn(backer_);
     }
 
     // -----------------------------

--- a/test/OptOutRewardsBehaviour.t.sol
+++ b/test/OptOutRewardsBehaviour.t.sol
@@ -37,7 +37,7 @@ contract OptOutRewardsBehaviour is BaseTest {
     }
 
     /**
-     * SCENARIO: Only foundation or the backer itself can OptOut
+     * SCENARIO: Only KYC approver or the backer itself can OptOut
      */
     function test_OptOutAuthorization() public {
         //  GIVEN alice tries to OptOut Bob
@@ -46,8 +46,8 @@ contract OptOutRewardsBehaviour is BaseTest {
         vm.expectRevert(BackersManagerRootstockCollective.NotAuthorized.selector);
         backersManager.optOutRewards(bob);
 
-        //  GIVEN foundation tries to OptOut Bob
-        vm.prank(foundation);
+        //  GIVEN KYC approver tries to OptOut Bob
+        vm.prank(kycApprover);
         //   THEN tx is successful
         vm.expectEmit();
         emit BackerRewardsOptedOut(bob);

--- a/test/OptOutRewardsBehaviour.t.sol
+++ b/test/OptOutRewardsBehaviour.t.sol
@@ -21,7 +21,7 @@ contract OptOutRewardsBehaviour is BaseTest {
         backersManager.optOutRewards(alice);
         //  WHEN alice tries to OptOut again
         //   THEN tx reverts because AlreadyOptedOut
-        vm.expectRevert(BackersManagerRootstockCollective.AlreadyOptedOutRewards.selector);
+        vm.expectRevert(BackersManagerRootstockCollective.BackerOptedOutRewards.selector);
         backersManager.optOutRewards(alice);
     }
 
@@ -82,8 +82,8 @@ contract OptOutRewardsBehaviour is BaseTest {
         vm.startPrank(alice);
         backersManager.allocate(gauge, 0.1 ether);
         //  WHEN alice tries to OptOut
-        //   THEN tx reverts because OptOutWithAllocations
-        vm.expectRevert(BackersManagerRootstockCollective.OptOutWithAllocations.selector);
+        //   THEN tx reverts because BackerHasAllocations
+        vm.expectRevert(BackersManagerRootstockCollective.BackerHasAllocations.selector);
         backersManager.optOutRewards(alice);
         //  WHEN alice removes the allocation
         backersManager.allocate(gauge, 0 ether);

--- a/test/OptOutRewardsBehaviour.t.sol
+++ b/test/OptOutRewardsBehaviour.t.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import { BaseTest, BackersManagerRootstockCollective } from "./BaseTest.sol";
+
+contract OptOutRewardsBehaviour is BaseTest {
+    // -----------------------------
+    // ----------- Events ----------
+    // -----------------------------
+
+    event NewAllocation(address indexed backer_, address indexed gauge_, uint256 allocation_);
+    event BackerRewardsOptedOut(address indexed backer_);
+    event BackerRewardsOptedIn(address indexed backer_);
+
+    /**
+     * SCENARIO: Can only OptOut if not already opted out
+     */
+    function test_OptOutAlreadyOptedOut() public {
+        // GIVEN alice OptOut
+        vm.startPrank(alice);
+        backersManager.optOutRewards(alice);
+        //  WHEN alice tries to OptOut again
+        //   THEN tx reverts because AlreadyOptedOut
+        vm.expectRevert(BackersManagerRootstockCollective.AlreadyOptedOutRewards.selector);
+        backersManager.optOutRewards(alice);
+    }
+
+    /**
+     * SCENARIO: Can only OptIn if already opted out
+     */
+    function test_OptInWhileNotOptedOutRevert() public {
+        // GIVEN alicetries to OptIn
+        vm.startPrank(alice);
+        //   THEN tx reverts because is not opted out
+        vm.expectRevert(BackersManagerRootstockCollective.AlreadyOptedInRewards.selector);
+        backersManager.optInRewards(alice);
+    }
+
+    /**
+     * SCENARIO: Only foundation or the backer itself can OptOut
+     */
+    function test_OptOutAuthorization() public {
+        //  GIVEN alice tries to OptOut Bob
+        vm.prank(alice);
+        //   THEN tx reverts because NotAuthorized
+        vm.expectRevert(BackersManagerRootstockCollective.NotAuthorized.selector);
+        backersManager.optOutRewards(bob);
+
+        //  GIVEN foundation tries to OptOut Bob
+        vm.prank(foundation);
+        //   THEN tx is successful
+        vm.expectEmit();
+        emit BackerRewardsOptedOut(bob);
+        backersManager.optOutRewards(bob);
+
+        // GIVEN alice tries to OptOut
+        vm.prank(alice);
+        //   THEN tx is successful
+        vm.expectEmit();
+        emit BackerRewardsOptedOut(alice);
+        backersManager.optOutRewards(alice);
+    }
+
+    /**
+     * SCENARIO: OptOut Backer cannot allocate
+     */
+    function test_OptOutAllocateRevert() public {
+        // GIVEN alice OptOut
+        vm.startPrank(alice);
+        backersManager.optOutRewards(alice);
+        //  WHEN alice tries to allocate
+        //   THEN tx reverts because OptedOut
+        vm.expectRevert(BackersManagerRootstockCollective.BackerOptedOutRewards.selector);
+        backersManager.allocate(gauge, 0.1 ether);
+    }
+
+    /**
+     * SCENARIO: Backer can only OptOut if has no allocations
+     */
+    function test_OptOutWithAllocation() public {
+        // GIVEN alice allocates 0.1 ether
+        vm.startPrank(alice);
+        backersManager.allocate(gauge, 0.1 ether);
+        //  WHEN alice tries to OptOut
+        //   THEN tx reverts because OptOutWithAllocations
+        vm.expectRevert(BackersManagerRootstockCollective.OptOutWithAllocations.selector);
+        backersManager.optOutRewards(alice);
+        //  WHEN alice removes the allocation
+        backersManager.allocate(gauge, 0 ether);
+        //  THEN alice can OptOut
+        vm.expectEmit();
+        emit BackerRewardsOptedOut(alice);
+        backersManager.optOutRewards(alice);
+    }
+
+    /**
+     * SCENARIO: OptIn Backer can allocate
+     */
+    function test_OptInAndAllocate() public {
+        // GIVEN alice OptOut
+        vm.startPrank(alice);
+        backersManager.optOutRewards(alice);
+        //  WHEN alice tries to allocate
+        //   THEN tx reverts because OptedOut
+        vm.expectRevert(BackersManagerRootstockCollective.BackerOptedOutRewards.selector);
+        backersManager.allocate(gauge, 0.1 ether);
+        //  WHEN alice OptIn
+        backersManager.optInRewards(alice);
+        //  THEN alice can allocate
+        vm.expectEmit();
+        emit NewAllocation(alice, address(gauge), 0.1 ether);
+        backersManager.allocate(gauge, 0.1 ether);
+    }
+}

--- a/test/OptOutRewardsBehaviour.t.sol
+++ b/test/OptOutRewardsBehaviour.t.sol
@@ -29,7 +29,7 @@ contract OptOutRewardsBehaviour is BaseTest {
      * SCENARIO: Can only OptIn if already opted out
      */
     function test_OptInWhileNotOptedOutRevert() public {
-        // GIVEN alicetries to OptIn
+        // GIVEN alice tries to OptIn
         vm.startPrank(alice);
         //   THEN tx reverts because is not opted out
         vm.expectRevert(BackersManagerRootstockCollective.AlreadyOptedInRewards.selector);


### PR DESCRIPTION
## What

- We need to introduce a Rewards opt-out mechanism in CR enabling users to voluntarily opt-in to restrict their wallets from receiving rewards or making allocations in Collective Rewards.

## Why

- This feature ensures transparency and prevents potential conflicts of interest.

## Testing

- Unit testing

## Refs

- [Jira ticket](https://rsklabs.atlassian.net/jira/software/projects/TOK/boards/267?assignee=712020%3A42dabdd3-0b32-4060-be21-62cfd46a1751&selectedIssue=TOK-568)
