### PR TITLE
feat: ensure v1 community approval compatibility

### DIFF
--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -376,6 +376,18 @@ contract BackersManagerRootstockCollective is
         emit BackerRewardsOptedIn(backer_);
     }
 
+    /**
+     * @notice This method allows ongoing v1 proposals to be executed after the BackersManager upgrade to v2, by keeping
+     * compatibility with the v1 interface.
+     */
+    function communityApproveBuilder(address builder_)
+        external
+        onlyValidChanger
+        returns (GaugeRootstockCollective gauge_)
+    {
+        return builderRegistry.communityApproveBuilder(builder_);
+    }
+
     // -----------------------------
     // ---- Internal Functions -----
     // -----------------------------

--- a/src/builderRegistry/BuilderRegistryRootstockCollective.sol
+++ b/src/builderRegistry/BuilderRegistryRootstockCollective.sol
@@ -71,6 +71,13 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
         _;
     }
 
+    modifier onlyValidChangerOrBackersManager() {
+        if (!governanceManager.isAuthorizedChanger(msg.sender) && msg.sender != address(backersManager)) {
+            revert NotAuthorized();
+        }
+        _;
+    }
+
     modifier onlyBackersManager() {
         if (msg.sender != address(backersManager)) {
             revert NotAuthorized();
@@ -298,7 +305,7 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
 
     /**
      * @notice community approve builder and create its gauge
-     * @dev reverts if it is not called by the governor address or authorized changer
+     * @dev reverts if it is not called by the governor, authorized changer nor the backers manager
      * reverts if is already community approved
      * reverts if it has a gauge associated
      * @param builder_ address of the builder
@@ -306,7 +313,7 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
      */
     function communityApproveBuilder(address builder_)
         external
-        onlyValidChanger
+        onlyValidChangerOrBackersManager
         returns (GaugeRootstockCollective gauge_)
     {
         return _communityApproveBuilder(builder_);

--- a/test/BuilderRegistryRootstockCollective.t.sol
+++ b/test/BuilderRegistryRootstockCollective.t.sol
@@ -56,7 +56,7 @@ contract BuilderRegistryRootstockCollectiveTest is BaseTest {
 
         // WHEN alice calls communityApproveBuilder
         //  THEN tx reverts because caller is not the Governor
-        vm.expectRevert(IGovernanceManagerRootstockCollective.NotAuthorizedChanger.selector);
+        vm.expectRevert(BuilderRegistryRootstockCollective.NotAuthorized.selector);
         builderRegistry.communityApproveBuilder(builder);
 
         // WHEN alice calls dewhitelistBuilder

--- a/test/governance/changers/CommunityApproveBuilderChanger.t.sol
+++ b/test/governance/changers/CommunityApproveBuilderChanger.t.sol
@@ -5,6 +5,7 @@ import { BaseTest, GaugeRootstockCollective } from "../../BaseTest.sol";
 import { CommunityApproveBuilderChangerTemplateRootstockCollective } from
     "../../../src/governance/changerTemplates/CommunityApproveBuilderChangerTemplateRootstockCollective.sol";
 import { IGovernanceManagerRootstockCollective } from "src/interfaces/IGovernanceManagerRootstockCollective.sol";
+import { BuilderRegistryRootstockCollective } from "src/builderRegistry/BuilderRegistryRootstockCollective.sol";
 
 contract CommunityApproveBuilderChangerTest is BaseTest {
     CommunityApproveBuilderChangerTemplateRootstockCollective internal _changer;
@@ -21,9 +22,9 @@ contract CommunityApproveBuilderChangerTest is BaseTest {
      */
     function test_RevertWhenIsNotAuthorized() public {
         //  WHEN tries to directly execute the changer
-        //   THEN tx reverts because NotGovernorOrAuthorizedChanger
+        //   THEN tx reverts because NotAuthorized
         vm.prank(alice);
-        vm.expectRevert(IGovernanceManagerRootstockCollective.NotAuthorizedChanger.selector);
+        vm.expectRevert(BuilderRegistryRootstockCollective.NotAuthorized.selector);
         _changer.execute();
     }
 


### PR DESCRIPTION
## What

- Maintain the community approval proposal interface in the BackersManager, to avoid failing proposals while migrating

## Why

- To ensure that ongoing community approval proposals during migration can still be successfully executed

## Testing

- unit tests

## Refs

- [Jira ticket](https://rsklabs.atlassian.net/jira/software/projects/TOK/boards/267?assignee=712020%3A42dabdd3-0b32-4060-be21-62cfd46a1751&selectedIssue=TOK-627)
