### PR TITLE
TOK-654: filter out fork test when running coverage report

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -1,5 +1,5 @@
 # generates lcov.info
-forge coverage --report lcov
+forge coverage --no-match-test '(fork)' --report lcov
 
 EXCLUDE="*test* *mock* *node_modules* *script*"
 lcov \

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "test:invariant": "forge test --match-test invariant",
     "test:integration": "hardhat test",
     "test:fork": "forge test --fork-url $RPC_URL_FORK --match-test fork",
-    "test:coverage": "forge coverage",
+    "test:coverage": "forge coverage --no-match-test '(fork)'",
     "test:coverage:report": "sh ./coverage.sh",
     "prepare": "husky",
     "docgen": "forge doc && bun run prettier:write"


### PR DESCRIPTION
## What

- do not run fork tests when measuring the coverage

## Why

- fork tests were just meant to test the migration

## Testing

- `bun run test:coverage`
- `bun run test:coverage:report`

We expect all the tests to succeed.
