### PR TITLE
Tok 679/erc20 approve not validated

### DIFF
--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -41,6 +41,7 @@ contract BackersManagerRootstockCollective is
     error AlreadyOptedInRewards();
     error BackerHasAllocations();
     error InvalidAddress();
+    error RewardTokenNotApproved();
 
     // -----------------------------
     // ----------- Events ----------
@@ -565,11 +566,15 @@ contract BackersManagerRootstockCollective is
     /**
      * @notice approves rewardTokens to a given gauge
      * @dev give full allowance when it is community approved and remove it when it is dewhitelisted
+     * reverts if the reward token contract returns false on the approval
      * @param gauge_ gauge contract to approve rewardTokens
      * @param value_ amount of rewardTokens to approve
      */
     function rewardTokenApprove(address gauge_, uint256 value_) external onlyBuilderRegistry {
-        IERC20(rewardToken).approve(gauge_, value_);
+        if(IERC20(rewardToken).approve(gauge_, value_)) {
+            revert RewardTokenNotApproved();
+        }
+        
     }
 
     /**

--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -571,7 +571,7 @@ contract BackersManagerRootstockCollective is
      * @param value_ amount of rewardTokens to approve
      */
     function rewardTokenApprove(address gauge_, uint256 value_) external onlyBuilderRegistry {
-        if(IERC20(rewardToken).approve(gauge_, value_)) {
+        if(!IERC20(rewardToken).approve(gauge_, value_)) {
             revert RewardTokenNotApproved();
         }
         

--- a/test/BackersManagerRootstockCollective.t.sol
+++ b/test/BackersManagerRootstockCollective.t.sol
@@ -113,7 +113,7 @@ contract BackersManagerRootstockCollectiveTest is BaseTest {
         backersManager.rewardTokenApprove(address(gauge), type(uint256).max);
 
         // Should revert, as the allowance is not negated before approving a new amount
-        vm.expectRevert(BackersManagerRootstockCollective.RewardTokenNotApproved.selector);
+vm.expectRevert(BackersManagerRootstockCollective.RewardTokenNotApproved.selector);
         backersManager.rewardTokenApprove(address(gauge), type(uint256).max);
     }
 

--- a/test/mock/ERC20Mock.sol
+++ b/test/mock/ERC20Mock.sol
@@ -7,7 +7,7 @@ string constant DEFAULT_NAME = "ERC20Mock";
 string constant DEFAULT_SYMBOL = "E20M";
 
 contract ERC20Mock is ERC20 {
-    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) { }
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
 
     function mint(address account_, uint256 amount_) external {
         _mint(account_, amount_);
@@ -15,5 +15,15 @@ contract ERC20Mock is ERC20 {
 
     function burn(address account_, uint256 amount_) external {
         _burn(account_, amount_);
+    }
+
+    function approve(address spender, uint256 value) public override returns (bool) {
+        // Prevent potential race condition (optional but safer. Used in legacy erc20 tokens)
+        if (value != 0 && allowance(msg.sender, spender) != 0) {
+            return false;
+        }
+        _approve(msg.sender, spender, value);
+        emit Approval(msg.sender, spender, value);
+        return true;
     }
 }


### PR DESCRIPTION
## What

Handling the scenarios of erc20 token returning false.

## Why

In most cases, this will not happen, as almost all erc20 standard tokens have their built-in reversion logic, but still, if the given token returns false on the approval, the contract will revert with the corresponding message.

## Testing

- There are not any separate unit tests written for this function as it is used by other contracts' functions that are being tested.
