### PR TITLE
TOK-682/potential-zero-address-update

### DIFF
--- a/src/governance/GovernanceManagerRootstockCollective.sol
+++ b/src/governance/GovernanceManagerRootstockCollective.sol
@@ -152,7 +152,7 @@ contract GovernanceManagerRootstockCollective is UUPSUpgradeable, IGovernanceMan
         emit KycApproverUpdated(kycApprover_, msg.sender);
     }
 
-    function _updateUpgrader(address upgrader_) private {
+    function _updateUpgrader(address upgrader_) private onlyValidAddress(upgrader_) {
         upgrader = upgrader_;
         emit UpgraderUpdated(upgrader_, msg.sender);
     }

--- a/test/governance/GovernanceManagerRootstockCollective.t.sol
+++ b/test/governance/GovernanceManagerRootstockCollective.t.sol
@@ -119,15 +119,38 @@ contract GovernanceManagerRootstockCollectiveTest is BaseTest {
     }
 
     /**
-     * SCENARIO: Updater can disable the role by updating the upgrader address to zero
+     * SCENARIO: functions should revert by InvalidAddress error when an address is invalid
      */
-    function test_UpdateUpgraderToZeroAddress() public {
-        // WHEN the governor updates the upgrader address to the zero address
-        vm.prank(upgrader);
-        governanceManager.updateUpgrader(address(0));
+    function test_InvalidAddress() public {
+        vm.startPrank(governor);
+        // WHEN governor calls updateGovernor using an invalid address
+        //  THEN tx reverts
+        vm.expectRevert(
+            abi.encodeWithSelector(IGovernanceManagerRootstockCollective.InvalidAddress.selector, address(0))
+        );
+        governanceManager.updateGovernor(address(0));
 
-        // THEN the upgrader address is updated
-        assertEq(governanceManager.upgrader(), address(0));
+        // WHEN governor calls updateGovernor using an invalid address
+        //  THEN tx reverts
+        vm.expectRevert(
+            abi.encodeWithSelector(IGovernanceManagerRootstockCollective.InvalidAddress.selector, address(0))
+        );
+        governanceManager.updateFoundationTreasury(address(0));
+
+        // WHEN governor calls updateKYCApprover using an invalid address
+        //  THEN tx reverts
+        vm.expectRevert(
+            abi.encodeWithSelector(IGovernanceManagerRootstockCollective.InvalidAddress.selector, address(0))
+        );
+        governanceManager.updateKYCApprover(address(0));
+
+        vm.startPrank(upgrader);
+        // WHEN governor calls updateUpgrader using an invalid address
+        //  THEN tx reverts
+        vm.expectRevert(
+            abi.encodeWithSelector(IGovernanceManagerRootstockCollective.InvalidAddress.selector, address(0))
+        );
+        governanceManager.updateUpgrader(address(0));
     }
 
     /**
@@ -226,8 +249,8 @@ contract GovernanceManagerRootstockCollectiveTest is BaseTest {
 
 /**
  * @title SampleChangeContract
- * @notice barebones constract that follows IChangeContractRootstockCollective interface
- * uset to test the execution of changes
+ * @notice barebones contract that follows IChangeContractRootstockCollective interface
+ * used to test the execution of changes
  */
 contract SampleChangeContract is IChangeContractRootstockCollective {
     bool public executed = false;


### PR DESCRIPTION
## What

- Add `onlyValidAddress` to `_updateUpgrader` in governor

## Why

- If an invalid address is set for upgrader, the contract might become un-upgradeable

## Testing

- bun run test

## Refs

- [TOK-682](https://rsklabs.atlassian.net/browse/TOK-682)
