### PR TITLE
Tok 542/redistribute opt out backers rewards

### DIFF
--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -305,6 +305,17 @@ contract BackersManagerRootstockCollective is
         }
     }
 
+    function collectOptedOutRewards(address backer_, GaugeRootstockCollective[] memory gauges_) external {
+        uint256 _length = gauges_.length;
+        BuilderRegistryRootstockCollective _builderRegistry = builderRegistry;
+        for (uint256 i = 0; i < _length; i = UtilsLib._uncheckedInc(i)) {
+            // reverts if builder was not activated or approved by the community
+            _builderRegistry.validateWhitelisted(gauges_[i]);
+
+            gauges_[i].collectOptedOutRewards(backer_);
+        }
+    }
+
     /**
      * @notice claims backer rewards from a batch of gauges
      * @param gauges_ array of gauges to claim

--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -82,13 +82,6 @@ contract BackersManagerRootstockCollective is
         _;
     }
 
-    modifier onlyOptedInBacker() {
-        if (rewardsOptedOut[msg.sender]) {
-            revert BackerOptedOutRewards();
-        }
-        _;
-    }
-
     // -----------------------------
     // ---------- Storage ----------
     // -----------------------------
@@ -204,14 +197,7 @@ contract BackersManagerRootstockCollective is
      * @param gauge_ address of the gauge where the votes will be allocated
      * @param allocation_ amount of votes to allocate
      */
-    function allocate(
-        GaugeRootstockCollective gauge_,
-        uint256 allocation_
-    )
-        external
-        notInDistributionPeriod
-        onlyOptedInBacker
-    {
+    function allocate(GaugeRootstockCollective gauge_, uint256 allocation_) external notInDistributionPeriod {
         (uint256 _newBackerTotalAllocation, uint256 _newTotalPotentialReward) = _allocate(
             gauge_,
             allocation_,
@@ -237,7 +223,6 @@ contract BackersManagerRootstockCollective is
     )
         external
         notInDistributionPeriod
-        onlyOptedInBacker
     {
         uint256 _length = gauges_.length;
         if (_length != allocations_.length) revert UnequalLengths();

--- a/src/gauge/GaugeRootstockCollective.sol
+++ b/src/gauge/GaugeRootstockCollective.sol
@@ -263,6 +263,9 @@ contract GaugeRootstockCollective is ReentrancyGuardUpgradeable {
      */
     function claimBackerReward(address rewardToken_, address backer_) public {
         if (msg.sender != backer_ && msg.sender != address(backersManager)) revert NotAuthorized();
+        if (backersManager.rewardsOptedOut(backer_)) {
+            revert BackersManagerRootstockCollective.BackerOptedOutRewards();
+        }
 
         RewardData storage _rewardData = rewardData[rewardToken_];
 


### PR DESCRIPTION
## What

- Send opt out backers rewards from gauges to the backers manager, so they are distributed next cycle.
As cycles progress, the opt out backers rewards will be flowing to all the opt in backers. 
To move the rewards from the opted out backers to the backer manager, 1 transaction is required per backer, each cycle. Each transaction should be roughly the same cost as a backer claim transaction.

Below a table that showcase the behavior:
## Rewards Distribution

**Rewards to be distributed:** 1000

| Cycle | Accumulated Rewards | Backers     | Whale       |
|-------|---------------------|-------------|-------------|
| 1     | 1000.000000         | 500.000000  | 500.000000  |
| 2     | 1500.000000         | 750.000000  | 750.000000  |
| 3     | 1750.000000         | 875.000000  | 875.000000  |
| 4     | 1875.000000         | 937.500000  | 937.500000  |
| 5     | 1937.500000         | 968.750000  | 968.750000  |
| 6     | 1968.750000         | 984.375000  | 984.375000  |
| 7     | 1984.375000         | 992.187500  | 992.187500  |
| 8     | 1992.187500         | 996.093750  | 996.093750  |
| 9     | 1996.093750         | 998.046875  | 998.046875  |
| 10    | 1998.046875         | 999.023438  | 999.023438  |
| 11    | 1999.023438         | 999.511719  | 999.511719  |


## Testing

- none

## Refs

- [Jira ticket](https://rsklabs.atlassian.net/jira/software/projects/TOK/boards/267?assignee=712020%3A42dabdd3-0b32-4060-be21-62cfd46a1751&selectedIssue=TOK-642)
