### PR TITLE
Tok 535/improve naming self paused unpaused

### DIFF
--- a/specs/CONTRACTS.md
+++ b/specs/CONTRACTS.md
@@ -38,7 +38,7 @@ Its main responsibility is to manage the Builders and their state. It allows to:
 - allow the Builder to change the Backers reward percentage
 - allow the Builder to replace the Builder reward receiver address
 - get the list of gauges
-- allow the Builders to revoke themselves.
+- allow the Builders to pause themselves.
 
 ## CycleTimeKeeper
 

--- a/specs/SPECIFICATION.md
+++ b/specs/SPECIFICATION.md
@@ -46,7 +46,7 @@ bool initialized;
 bool kycApproved;
 bool communityApproved;
 bool paused;
-bool revoked;
+bool selfPaused;
 bytes7 reserved; // for future upgrades
 bytes20 pausedReason;
 ```
@@ -54,33 +54,33 @@ bytes20 pausedReason;
 - `kycApproved`: it's set when the Builder is KYC approved (`BuilderRegistry#activateBuilder()` or `BuilderRegistry#approveBuilderKYC()`) and it can be unset when the KYC is revoked (`BuilderRegistry#revokeBuilderKYC()`).
 - `communityApproved`: it's set when the Builder is community approved (`BuilderRegistry#communityApproveBuilder()`) and unset when the community approval is removed (`BuilderRegistry#dewhitelistBuilder()`). **Once the flag is unset, it cannot be reset again**.
 - `paused`: this flag can be used by the KYC Approver to temporarily pause a Builder (`BuilderRegistry#pauseBuilder()`) because of additional checks required on that Builder. The KYC approver can specify a reason (`pausedReason`) when pausing the Builder. It's unset by the KYC Approver also (`BuilderRegistry#unpauseBuilder()`) and this flag can be set and unset at any time.
-- `revoked`: this flag is set by the Builders themselves if they don't want to participate to CR (`BuilderRegistry#revokeBuilder()`). It's also unset by the Builders when they want to be part of CR again (`BuilderRegistry#permitBuilder`).
+- `selfPaused`: this flag is set by the Builders themselves if they don't want to participate to CR (`BuilderRegistry#pauseSelf()`). It's also unset by the Builders when they want to be part of CR again (`BuilderRegistry#unpauseSelf`).
 - `initialized`: it's activated once either when the Builder is KYC approved for the first time (`BuilderRegistry#initializeBuilder()`). This flag will never be unset.
 
 ### Conditions required to switch the Builder's flags
 
-| Action                    | Paused    | Revoked   | KYC Approved  | Activated | Community Approved    |
-|---------------------------|:---------:|:---------:|:-------------:|:---------:|:---------------------:|
-| InitializeBuilder         |   -       |   -       |   -           |   False   |   -                   |
-| CommunityApproveBuilder   |   -       |   -       |   -           |   -       |   False               |
-| ApproveBuilderKYC         |   -       |   -       |   False       |   True    |   -                   |
-| RevokeBuilderKYC          |   -       |   -       |   True        |   -       |   -                   |
-| RevokeBuilder             |   -       |   False   |   True        |   -       |   True                |
-| PermitBuilder             |   -       |   True    |   True        |   -       |   True                |
-| PauseBuilder              |   -       |   -       |   -           |   -       |   -                   |
-| UnpauseBuilder            |   True    |   -       |   -           |   -       |   -                   |
-| DewhitelistBuilder        |   -       |   -       |   -           |   -       |   True                |
+| Action                    | Paused    | Self Paused | KYC Approved  | Activated | Community Approved    |
+|---------------------------|:---------:|:-----------:|:-------------:|:---------:|:---------------------:|
+| ActivateBuilder           |   -       |     -       |   -           |   False   |   -                   |
+| CommunityApproveBuilder   |   -       |     -       |   -           |   -       |   False               |
+| ApproveBuilderKYC         |   -       |     -       |   False       |   True    |   -                   |
+| RevokeBuilderKYC          |   -       |     -       |   True        |   -       |   -                   |
+| PauseSelf                 |   -       |     False   |   True        |   -       |   True                |
+| UnpauseSelf               |   -       |     True    |   True        |   -       |   True                |
+| PauseBuilder              |   -       |     -       |   -           |   -       |   -                   |
+| UnpauseBuilder            |   True    |     -       |   -           |   -       |   -                   |
+| DewhitelistBuilder        |   -       |     -       |   -           |   -       |   True                |
 
 ### Conditions required to execute actions:
 
-| Action                    | Paused    | Revoked   | KYC Approved  | Activated | Community Approved    |
-|---------------------------|:---------:|:---------:|:-------------:|:---------:|:---------------------:|
-| Allocate (increase)       |   -       |   False   |   True        |   -       |  True                 |
-| Allocate (decrease)       |   -       |   -       |   -           |   -       |  -                    |
-| Included in distribution  |   -       |   False   |   True        |   -       |  True                 |
-| Incentivize               |   -       |   False   |   True        |   -       |  True                 |
-| Updated reward percentage |   False   |   -       |   True        |   -       |  True                 |
-| Updated reward receiver   |   False   |   -       |   True        |   -       |  True                 |
+| Action                    | Paused    | Self Paused | KYC Approved  | Activated | Community Approved    |
+|---------------------------|:---------:|:-----------:|:-------------:|:---------:|:---------------------:|
+| Allocate (increase)       |   -       |    False    |   True        |   -       |  True                 |
+| Allocate (decrease)       |   -       |    -        |   -           |   -       |  -                    |
+| Included in distribution  |   -       |    False    |   True        |   -       |  True                 |
+| Incentivize               |   -       |    False    |   True        |   -       |  True                 |
+| Updated reward percentage |   False   |    -        |   True        |   -       |  True                 |
+| Updated reward receiver   |   False   |    -        |   True        |   -       |  True                 |
 
 ## Rewards calculation
 

--- a/test/BackersManagerRootstockCollective.t.sol
+++ b/test/BackersManagerRootstockCollective.t.sol
@@ -339,9 +339,9 @@ contract BackersManagerRootstockCollectiveTest is BaseTest {
         vm.prank(alice);
         backersManager.allocateBatch(gaugesArray, allocationsArray);
 
-        // AND first builder gets revoked
+        // AND first builder pauses itself
         vm.prank(builder);
-        builderRegistry.revokeBuilder();
+        builderRegistry.pauseSelf();
 
         // WHEN alice moves votes from revoked gauge to the other
         allocationsArray[0] = 0 ether;
@@ -514,7 +514,7 @@ contract BackersManagerRootstockCollectiveTest is BaseTest {
         backersManager.allocateBatch(gaugesArray, allocationsArray);
 
         vm.prank(builder2);
-        builderRegistry.revokeBuilder();
+        builderRegistry.pauseSelf();
 
         //  AND 2 ether reward are added
         backersManager.notifyRewardAmount(2 ether);
@@ -535,16 +535,16 @@ contract BackersManagerRootstockCollectiveTest is BaseTest {
         //  THEN tx reverts because NotInDistributionPeriod
         vm.expectRevert(BackersManagerRootstockCollective.NotInDistributionPeriod.selector);
         backersManager.startDistribution();
-        // WHEN tries to revoke a builder
+        // WHEN builder tries to pause himself
         //  THEN tx reverts because NotInDistributionPeriod
         vm.prank(builder);
         vm.expectRevert(BackersManagerRootstockCollective.NotInDistributionPeriod.selector);
-        builderRegistry.revokeBuilder();
-        // WHEN tries to permit a builder
+        builderRegistry.pauseSelf();
+        // WHEN tries builder2 tries to unpause himself
         //  THEN tx reverts because NotInDistributionPeriod
         vm.prank(builder2);
         vm.expectRevert(BackersManagerRootstockCollective.NotInDistributionPeriod.selector);
-        builderRegistry.permitBuilder(0.1 ether);
+        builderRegistry.unpauseSelf(0.1 ether);
     }
 
     /**

--- a/test/BuilderRegistryRootstockCollective.t.sol
+++ b/test/BuilderRegistryRootstockCollective.t.sol
@@ -405,13 +405,13 @@ contract BuilderRegistryRootstockCollectiveTest is BaseTest {
     /**
      * SCENARIO: pauseSelf should revert if it is already self paused
      */
-    function test_RevertBuilderAlreadyPausedSelf() public {
+    function test_RevertBuilderAlreadySelfPaused() public {
         // GIVEN a self paused builder
         vm.startPrank(builder);
         builderRegistry.pauseSelf();
         // WHEN tries to pauseSelf again
         //  THEN tx reverts because is already self paused
-        vm.expectRevert(BuilderRegistryRootstockCollective.BuilderAlreadyPausedSelf.selector);
+        vm.expectRevert(BuilderRegistryRootstockCollective.BuilderAlreadySelfPaused.selector);
         builderRegistry.pauseSelf();
     }
 

--- a/test/PauseBuilder.t.sol
+++ b/test/PauseBuilder.t.sol
@@ -183,7 +183,7 @@ contract PauseBuilderTest is BaseTest {
     }
 
     /**
-     * SCENARIO: revoked builder is paused
+     * SCENARIO: self paused builder is paused by the kycApprover
      *  If the builder calls claimBuilderReward the tx reverts
      */
     function test_RevokedGaugeIsPaused() public {
@@ -191,9 +191,9 @@ contract PauseBuilderTest is BaseTest {
         //  AND 100 rewardToken and 10 coinbase are distributed
         //   AND half cycle pass
         _initialDistribution();
-        // AND builder is revoked
+        // AND builder pauses himself
         vm.startPrank(builder);
-        builderRegistry.revokeBuilder();
+        builderRegistry.pauseSelf();
         // AND builder is paused
         vm.startPrank(kycApprover);
         builderRegistry.pauseBuilder(builder, "paused");

--- a/test/RevokeKYC.t.sol
+++ b/test/RevokeKYC.t.sol
@@ -160,9 +160,9 @@ contract RevokeKYCTest is HaltedBuilderBehavior, ResumeBuilderBehavior {
         //  AND 100 rewardToken and 10 coinbase are distributed
         //   AND half cycle pass
         _initialDistribution();
-        // AND builder is revoked
+        // AND builder pauses himself
         vm.startPrank(builder);
-        builderRegistry.revokeBuilder();
+        builderRegistry.pauseSelf();
         // AND builder is KYC revoked
         vm.startPrank(kycApprover);
         builderRegistry.revokeBuilderKYC(builder);
@@ -200,9 +200,9 @@ contract RevokeKYCTest is HaltedBuilderBehavior, ResumeBuilderBehavior {
         //  AND 100 rewardToken and 10 coinbase are distributed
         //   AND half cycle pass
         _initialDistribution();
-        // AND builder is revoked
+        // AND builder pauses himself
         vm.startPrank(builder);
-        builderRegistry.revokeBuilder();
+        builderRegistry.pauseSelf();
         // AND builder is KYC revoked
         vm.startPrank(kycApprover);
         builderRegistry.revokeBuilderKYC(builder);
@@ -223,9 +223,9 @@ contract RevokeKYCTest is HaltedBuilderBehavior, ResumeBuilderBehavior {
         // THEN total allocation is 8467200 ether = 14 * 1 WEEK
         assertEq(backersManager.totalPotentialReward(), 8_467_200 ether);
 
-        // AND builder is permitted again
+        // AND builder unpauses himself again
         vm.startPrank(builder);
-        builderRegistry.permitBuilder(0.1 ether);
+        builderRegistry.unpauseSelf(0.1 ether);
 
         // THEN gauge is not halted anymore
         assertEq(builderRegistry.isGaugeHalted(address(gauge)), false);

--- a/test/integration/SkipDistribution.t.sol
+++ b/test/integration/SkipDistribution.t.sol
@@ -503,16 +503,16 @@ contract SkipDistribution is BaseTest {
     }
 
     /**
-     * SCENARIO: if there is a skipped distribution and builder gets revoked and permitted,
+     * SCENARIO: if there is a skipped distribution and builder gets self paused and self unpaused,
      * incentives are not lost
      * - There is a builder with no allocations that receives an incentive
-     * - Builder gets revoked
-     * - A distribution is skipped and builder can't be permitted
-     * - There is a distribution with no rewards and builder gets permitted
+     * - Builder gets self paused
+     * - A distribution is skipped and builder can't self unpause
+     * - There is a distribution with no rewards and builder unpauses himself
      * - There are votes for builder
      * - Rewards are not lost and can be claimed by sponsors and builder
      */
-    function test_integration_NoDistributionAndRevokedIncentivizedBuilder() public {
+    function test_integration_NoDistributionAndSelfPausedIncentivizedBuilder() public {
         // CYCLE 1
         // GIVEN bob allocates to gauge2 - this way there are allocations
         vm.prank(bob);
@@ -528,26 +528,26 @@ contract SkipDistribution is BaseTest {
         // AND half an cycle passes
         _skipRemainingCycleFraction(2);
 
-        // AND builder (gauge) gets revoked
+        // AND builder (gauge) pauses itself
         vm.prank(builder);
-        builderRegistry.revokeBuilder();
+        builderRegistry.pauseSelf();
 
         // CYCLE 3
         // AND cycle finishes without a distribution
         _skipAndStartNewCycle();
 
-        // THEN builder can't be permitted before distribution
+        // THEN builder can't self unpause before distribution
         vm.expectRevert(BackersManagerRootstockCollective.BeforeDistribution.selector);
         vm.prank(builder);
-        builderRegistry.permitBuilder(0.5 ether);
+        builderRegistry.unpauseSelf(0.5 ether);
 
         // CYCLE 4
         // AND there is a distribution
         _distribute(0, 0);
 
-        // AND builder is permitted again
+        // AND builder unpauses himself again
         vm.prank(builder);
-        builderRegistry.permitBuilder(0.5 ether);
+        builderRegistry.unpauseSelf(0.5 ether);
 
         // AND alice allocates to gauge
         vm.prank(alice);
@@ -576,15 +576,15 @@ contract SkipDistribution is BaseTest {
     }
 
     /**
-     * SCENARIO: if there is a skipped distribution and builder gets revoked and permitted,
+     * SCENARIO: if there is a skipped distribution and builder gets self paused and self unpaused,
      * incentives and rewards from distribution are not lost
-     * - A distribution is skipped and builder can't be permitted
-     * - There is a distribution and builder gets permitted
-     * - There is a distribution with no rewards and builder gets permitted
+     * - A distribution is skipped and builder can't self unpause
+     * - There is a distribution and builder self unpauses
+     * - There is a distribution with no rewards and builder unpauses himself
      * - There are votes for builder
      * - Rewards are not lost and can be claimed by sponsors and builder
      */
-    function test_integration_NoDistributionAndRevokedIncentivizedandRewardsBuilder() public {
+    function test_integration_NoDistributionAndSelfPausedIncentivizedandRewardsBuilder() public {
         // CYCLE 1
         // GIVEN bob allocates to gauge2 - this way there are allocations
         vm.prank(bob);
@@ -600,9 +600,9 @@ contract SkipDistribution is BaseTest {
         // AND half an cycle passes
         _skipRemainingCycleFraction(2);
 
-        // AND builder (gauge) gets revoked
+        // AND builder (gauge) gets self paused
         vm.prank(builder);
-        builderRegistry.revokeBuilder();
+        builderRegistry.pauseSelf();
 
         // CYCLE 3
         // AND cycle finishes without a distribution
@@ -611,9 +611,9 @@ contract SkipDistribution is BaseTest {
         // AND there is a distribution
         _distribute(0, 0);
 
-        // AND builder is permitted again
+        // AND builder is self unpaused again
         vm.prank(builder);
-        builderRegistry.permitBuilder(0.5 ether);
+        builderRegistry.unpauseSelf(0.5 ether);
 
         // AND alice allocates to gauge
         vm.prank(alice);

--- a/test/invariant/handlers/BuilderHandler.sol
+++ b/test/invariant/handlers/BuilderHandler.sol
@@ -7,24 +7,24 @@ import { BaseTest } from "../../BaseTest.sol";
 contract BuilderHandler is BaseHandler {
     constructor(BaseTest baseTest_, TimeManager timeManager_) BaseHandler(baseTest_, timeManager_) { }
 
-    function revokeBuilder(uint256 builderIndex_, uint256 timeToSkip_) external skipTime(timeToSkip_) {
+    function pauseSelf(uint256 builderIndex_, uint256 timeToSkip_) external skipTime(timeToSkip_) {
         builderIndex_ = bound(builderIndex_, 0, baseTest.buildersArrayLength() - 1);
         address _builder = baseTest.builders(builderIndex_);
-        (, bool _kycApproved, bool _communityApproved,, bool _revoked,,) = builderRegistry.builderState(_builder);
-        if (_kycApproved && _communityApproved && !_revoked) {
+        (, bool _kycApproved, bool _communityApproved,, bool _selfPaused,,) = builderRegistry.builderState(_builder);
+        if (_kycApproved && _communityApproved && !_selfPaused) {
             vm.prank(_builder);
-            builderRegistry.revokeBuilder();
+            builderRegistry.pauseSelf();
         }
     }
 
-    function permitBuilder(uint256 builderIndex_, uint256 timeToSkip_) external skipTime(timeToSkip_) {
+    function unpauseSelf(uint256 builderIndex_, uint256 timeToSkip_) external skipTime(timeToSkip_) {
         if (block.timestamp >= backersManager.periodFinish()) return;
         builderIndex_ = bound(builderIndex_, 0, baseTest.buildersArrayLength() - 1);
         address _builder = baseTest.builders(builderIndex_);
-        (, bool _kycApproved, bool _communityApproved,, bool _revoked,,) = builderRegistry.builderState(_builder);
-        if (_kycApproved && _communityApproved && _revoked) {
+        (, bool _kycApproved, bool _communityApproved,, bool _selfPaused,,) = builderRegistry.builderState(_builder);
+        if (_kycApproved && _communityApproved && _selfPaused) {
             vm.prank(_builder);
-            builderRegistry.permitBuilder(0.4 ether);
+            builderRegistry.unpauseSelf(0.4 ether);
         }
     }
 }


### PR DESCRIPTION
## What

- Renaming PR divided for each related change. This PR contains the builder renaming change from `revoke` to `pauseSelf` and `permit` to `unpauseSelf`

## Refs

- [JIRA](https://rsklabs.atlassian.net/jira/software/projects/TOK/boards/267?assignee=712020%3A42dabdd3-0b32-4060-be21-62cfd46a1751&selectedIssue=TOK-535)