### PR TITLE
Tok 535/improve naming reward receiver

### DIFF
--- a/specs/CONTRACTS.md
+++ b/specs/CONTRACTS.md
@@ -36,7 +36,7 @@ Its main responsibility is to manage the Builders and their state. It allows to:
 - store Backers reward percentage
 - keep track of the Builder<->Gauge association
 - allow the Builder to change the Backers reward percentage
-- allow the Builder to replace the Builder reward receiver address
+- allow the Builder to update the Builder reward receiver address
 - get the list of gauges
 - allow the Builders to pause themselves.
 

--- a/specs/PERMISSIONS.md
+++ b/specs/PERMISSIONS.md
@@ -46,7 +46,7 @@ You can find bellow the permissions, roles, and functionalities within the `Buil
 - Permissions and Capabilities:
     + Approve builder's KYC using `approveBuilderKYC`.
     + Revoke builder's KYC using `revokeBuilderKYC`.
-    + Approve builder's reward receiver replacement using `approveBuilderRewardReceiverReplacement`.
+    + Approve builder's new reward receiver using `approveNewRewardReceiver`.
     + Pause and unpause builder using `pauseBuilder` and `unpauseBuilder`.
     + Initialize builder using `initializeBuilder`.
     + Migrate builder using `migrateBuilder`.

--- a/src/interfaces/IBackersManagerRootstockCollective.sol
+++ b/src/interfaces/IBackersManagerRootstockCollective.sol
@@ -20,12 +20,12 @@ interface IBackersManagerRootstockCollective {
     /**
      * @notice returns rewards receiver for a given builder
      */
-    function builderRewardReceiver(address builder_) external view returns (address rewardReceiver_);
+    function rewardReceiver(address builder_) external view returns (address rewardReceiver_);
 
     /**
-     * @notice returns true if the builder has an open request to replace his receiver address
+     * @notice returns true if the builder has an open request to update his receiver address
      */
-    function hasBuilderRewardReceiverPendingApproval(address builder_) external view returns (bool);
+    function isRewardReceiverUpdatePending(address builder_) external view returns (bool);
 
     /**
      * @notice return true if builder is paused

--- a/test/BuilderRegistryRootstockCollective.t.sol
+++ b/test/BuilderRegistryRootstockCollective.t.sol
@@ -121,7 +121,7 @@ contract BuilderRegistryRootstockCollectiveTest is BaseTest {
         assertEq(_communityApproved, false);
 
         // THEN builder rewards receiver is set
-        assertEq(builderRegistry.builderRewardReceiver(_newBuilder), _newRewardReceiver);
+        assertEq(builderRegistry.rewardReceiver(_newBuilder), _newRewardReceiver);
 
         (uint64 _previous, uint64 _next, uint128 _cooldownEndTime) = builderRegistry.backerRewardPercentage(_newBuilder);
         // THEN previous backer reward percentage is 10%

--- a/test/GaugeRootstockCollective.t.sol
+++ b/test/GaugeRootstockCollective.t.sol
@@ -1051,7 +1051,7 @@ contract GaugeRootstockCollectiveTest is BaseTest {
      * SCENARIO: reward receiver tries to claim his rewards with a pending reward receiver address request.
      *           After KYC approval, he can complete the claim.
      */
-    function test_ClaimBuilderRewardsRewardReceiverWithReplacement() public {
+    function test_ClaimBuilderRewardsRewardReceiverWithUpdate() public {
         // GIVEN a builder2 with 30% of reward percentage
         vm.prank(builder2);
         builderRegistry.setBackerRewardPercentage(0.3 ether);
@@ -1072,13 +1072,13 @@ contract GaugeRootstockCollectiveTest is BaseTest {
         // AND another cycle finishes without a new distribution
         _skipAndStartNewCycle();
 
-        // AND Builder submits a Reward Receiver Replacement Request
+        // AND Builder submits a Reward Receiver Request update
         vm.prank(builder2);
         address _newRewardReceiver = makeAddr("newRewardReceiver");
-        builderRegistry.submitRewardReceiverReplacementRequest(_newRewardReceiver);
+        builderRegistry.requestRewardReceiverUpdate(_newRewardReceiver);
 
         // WHEN newRewardReceiver tries to claim rewards
-        // THEN it fails as there is an active reward receiver replacement request
+        // THEN it fails as there is an active reward receiver update request
         vm.expectRevert(GaugeRootstockCollective.NotAuthorized.selector);
         vm.prank(builder2Receiver);
         gauge2.claimBuilderReward();
@@ -1089,9 +1089,9 @@ contract GaugeRootstockCollectiveTest is BaseTest {
         // THEN he receives the reward in the original receiver address
         assertEq(rewardToken.balanceOf(builder2Receiver), 70 ether);
 
-        // WHEN KYCApprover approved his Reward Receiver Replacement Request
+        // WHEN KYCApprover approved his Reward Receiver update Request
         vm.prank(kycApprover);
-        builderRegistry.approveBuilderRewardReceiverReplacement(builder2, _newRewardReceiver);
+        builderRegistry.approveNewRewardReceiver(builder2, _newRewardReceiver);
 
         // AND 100 rewardToken and 100 coinbase are distributed
         _distribute(100 ether, 100 ether);

--- a/test/RewardReceiverUpdate.t.sol
+++ b/test/RewardReceiverUpdate.t.sol
@@ -5,7 +5,7 @@ import { BaseTest } from "./BaseTest.sol";
 import { BuilderRegistryRootstockCollective } from "../src/builderRegistry/BuilderRegistryRootstockCollective.sol";
 import { IGovernanceManagerRootstockCollective } from "src/interfaces/IGovernanceManagerRootstockCollective.sol";
 
-contract SetBuilderRewardReceiverTest is BaseTest {
+contract RewardReceiverUpdateTest is BaseTest {
     // -----------------------------
     // ----------- Events ----------
     // -----------------------------
@@ -35,7 +35,7 @@ contract SetBuilderRewardReceiverTest is BaseTest {
     /**
      * SCENARIO: requestRewardReceiverUpdate should revert if is not called by the builder
      */
-    function test_submitterIsNotABuilder() public {
+    function test_requesterIsNotABuilder() public {
         // GIVEN a whitelisted builder
         //  WHEN calls requestRewardReceiverUpdate
         //   THEN tx reverts because caller is not an operational builder


### PR DESCRIPTION
## What

- Renaming PR divided for each related change. This PR contains the builder renaming change from `reward receiver replacement` to `reward receiver updates`

## Refs

- [JIRA](https://rsklabs.atlassian.net/jira/software/projects/TOK/boards/267?assignee=712020%3A42dabdd3-0b32-4060-be21-62cfd46a1751&selectedIssue=TOK-535)