### PR TITLE
Tok 535/improve naming kyc paused

### DIFF
--- a/specs/CONTRACTS.md
+++ b/specs/CONTRACTS.md
@@ -32,7 +32,7 @@ Its main responsibility is to manage the Builders and their state. It allows to:
 - revoke Builders KYC
 - community approve Builders
 - remove community approval for the Builders
-- pause/unpause Builders
+- pause/unpause Builders KYC
 - store Backers reward percentage
 - keep track of the Builder<->Gauge association
 - allow the Builder to change the Backers reward percentage

--- a/specs/PERMISSIONS.md
+++ b/specs/PERMISSIONS.md
@@ -48,7 +48,7 @@ You can find bellow the permissions, roles, and functionalities within the `Buil
     + Revoke builder's KYC using `revokeBuilderKYC`.
     + Approve builder's reward receiver replacement using `approveBuilderRewardReceiverReplacement`.
     + Activate builder using `activateBuilder`.
-    + Pause and unpause builder using `pauseBuilder` and `unpauseBuilder`.
+    + Pause and unpause builder KYC using `pauseBuilderKYC` and `unpauseBuilderKYC`.
     + Migrate builder using `migrateBuilder`.
 
 ### Authorized Changer

--- a/specs/SPECIFICATION.md
+++ b/specs/SPECIFICATION.md
@@ -54,7 +54,7 @@ bytes20 pausedReason;
 - `activated`: it's activated once either when the Builder is KYC approved for the first time (`BuilderRegistry#activateBuilder()`) or when it's migrated from v1 (`BuilderRegistry#migrateBuilder()`) and it will never be unset.
 - `kycApproved`: it's set when the Builder is KYC approved (`BuilderRegistry#activateBuilder()` or `BuilderRegistry#approveBuilderKYC()`) or when the Builder is migrated from v1 (`BuilderRegistry#migrateBuilder()`) and it can be unset when the KYC is revoked (`BuilderRegistry#revokeBuilderKYC()`).
 - `communityApproved`: it's set when the Builder is community approved (`BuilderRegistry#communityApproveBuilder()`) and unset when the community approval is removed (`BuilderRegistry#dewhitelistBuilder()`). **Once the flag is unset, it cannot be reset again**.
-- `paused`: this flag can be used by the KYC Approver to temporarily pause a Builder (`BuilderRegistry#pauseBuilder()`) because of additional checks required on that Builder. The KYC approver can specify a reason (`pausedReason`) when pausing the Builder. It's unset by the KYC Approver also (`BuilderRegistry#unpauseBuilder()`) and this flag can be set and unset at any time.
+- `paused`: this flag can be used by the KYC Approver to temporarily pause a Builder (`BuilderRegistry#pauseBuilderKYC()`) because of additional checks required on that Builder. The KYC approver can specify a reason (`pausedReason`) when pausing the Builder. It's unset by the KYC Approver also (`BuilderRegistry#unpauseBuilderKYC()`) and this flag can be set and unset at any time.
 - `revoked`: this flag is set by the Builders themselves if they don't want to participate to CR (`BuilderRegistry#revokeBuilder()`). It's also unset by the Builders when they want to be part of CR again (`BuilderRegistry#permitBuilder`).
 
 ### Conditions required to switch the Builder's flags
@@ -67,8 +67,8 @@ bytes20 pausedReason;
 | RevokeBuilderKYC          |   -       |   -       |   True        |   -       |   -                   |
 | RevokeBuilder             |   -       |   False   |   True        |   -       |   True                |
 | PermitBuilder             |   -       |   True    |   True        |   -       |   True                |
-| PauseBuilder              |   -       |   -       |   -           |   -       |   -                   |
-| UnpauseBuilder            |   True    |   -       |   -           |   -       |   -                   |
+| PauseBuilderKYC           |   -       |   -       |   -           |   -       |   -                   |
+| UnpauseBuilderKYC         |   True    |   -       |   -           |   -       |   -                   |
 | DewhitelistBuilder        |   -       |   -       |   -           |   -       |   True                |
 
 ### Conditions required to execute actions:

--- a/src/builderRegistry/BuilderRegistryRootstockCollective.sol
+++ b/src/builderRegistry/BuilderRegistryRootstockCollective.sol
@@ -27,7 +27,7 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
     error NotActivated();
     error NotKYCApproved();
     error NotCommunityApproved();
-    error NotPaused();
+    error BuilderNotKYCPaused();
     error NotRevoked();
     error NotOperational();
     error InvalidBackerRewardPercentage();
@@ -47,8 +47,8 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
     event KYCRevoked(address indexed builder_);
     event CommunityApproved(address indexed builder_);
     event Dewhitelisted(address indexed builder_);
-    event Paused(address indexed builder_, bytes20 reason_);
-    event Unpaused(address indexed builder_);
+    event KYCPaused(address indexed builder_, bytes20 reason_);
+    event KYCResumed(address indexed builder_);
     event Revoked(address indexed builder_);
     event Permitted(address indexed builder_, uint256 rewardPercentage_, uint256 cooldown_);
     event BackerRewardPercentageUpdateScheduled(address indexed builder_, uint256 rewardPercentage_, uint256 cooldown_);
@@ -91,7 +91,7 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
         bool activated;
         bool kycApproved;
         bool communityApproved;
-        bool paused;
+        bool kycPaused;
         bool revoked;
         bytes7 reserved; // for future upgrades
         bytes20 pausedReason;
@@ -339,31 +339,31 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
     }
 
     /**
-     * @notice pause builder
+     * @notice pause builder KYC
      * @dev reverts if it is not called by the owner address
      * @param builder_ address of the builder
      * @param reason_ reason for the pause
      */
-    function pauseBuilder(address builder_, bytes20 reason_) external onlyKycApprover {
+    function pauseBuilderKYC(address builder_, bytes20 reason_) external onlyKycApprover {
         // pause can be overwritten to change the reason
-        builderState[builder_].paused = true;
+        builderState[builder_].kycPaused = true;
         builderState[builder_].pausedReason = reason_;
-        emit Paused(builder_, reason_);
+        emit KYCPaused(builder_, reason_);
     }
 
     /**
-     * @notice unpause builder
+     * @notice unpause builder KYC
      * @dev reverts if it is not called by the owner address
      * reverts if it is not paused
      * @param builder_ address of the builder
      */
-    function unpauseBuilder(address builder_) external onlyKycApprover {
-        if (!builderState[builder_].paused) revert NotPaused();
+    function unpauseBuilderKYC(address builder_) external onlyKycApprover {
+        if (!builderState[builder_].kycPaused) revert BuilderNotKYCPaused();
 
-        builderState[builder_].paused = false;
+        builderState[builder_].kycPaused = false;
         builderState[builder_].pausedReason = "";
 
-        emit Unpaused(builder_);
+        emit KYCResumed(builder_);
     }
 
     /**
@@ -495,14 +495,14 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
      */
     function isBuilderOperational(address builder_) public view returns (bool) {
         BuilderState memory _builderState = builderState[builder_];
-        return _builderState.kycApproved && _builderState.communityApproved && !_builderState.paused;
+        return _builderState.kycApproved && _builderState.communityApproved && !_builderState.kycPaused;
     }
 
     /**
      * @notice return true if builder is paused
      */
     function isBuilderPaused(address builder_) public view returns (bool) {
-        return builderState[builder_].paused;
+        return builderState[builder_].kycPaused;
     }
 
     /**

--- a/test/BuilderRegistryRootstockCollective.t.sol
+++ b/test/BuilderRegistryRootstockCollective.t.sol
@@ -14,8 +14,8 @@ contract BuilderRegistryRootstockCollectiveTest is BaseTest {
     event KYCRevoked(address indexed builder_);
     event CommunityApproved(address indexed builder_);
     event Dewhitelisted(address indexed builder_);
-    event Paused(address indexed builder_, bytes20 reason_);
-    event Unpaused(address indexed builder_);
+    event KYCPaused(address indexed builder_, bytes20 reason_);
+    event KYCResumed(address indexed builder_);
     event Revoked(address indexed builder_);
     event Permitted(address indexed builder_, uint256 rewardPercentage_, uint256 cooldown_);
     event GaugeCreated(address indexed builder_, address indexed gauge_, address creator_);
@@ -34,15 +34,15 @@ contract BuilderRegistryRootstockCollectiveTest is BaseTest {
         vm.expectRevert(IGovernanceManagerRootstockCollective.NotKycApprover.selector);
         builderRegistry.revokeBuilderKYC(builder);
 
-        // WHEN alice calls pauseBuilder
+        // WHEN alice calls pauseBuilderKYC
         //  THEN tx reverts because caller is not the owner
         vm.expectRevert(IGovernanceManagerRootstockCollective.NotKycApprover.selector);
-        builderRegistry.pauseBuilder(builder, "paused");
+        builderRegistry.pauseBuilderKYC(builder, "paused");
 
-        // WHEN alice calls unpauseBuilder
+        // WHEN alice calls unpauseBuilderKYC
         //  THEN tx reverts because caller is not the owner
         vm.expectRevert(IGovernanceManagerRootstockCollective.NotKycApprover.selector);
-        builderRegistry.unpauseBuilder(builder);
+        builderRegistry.unpauseBuilderKYC(builder);
         vm.stopPrank();
     }
 
@@ -236,78 +236,77 @@ contract BuilderRegistryRootstockCollectiveTest is BaseTest {
     }
 
     /**
-     * SCENARIO: kycApprover pause a builder
+     * SCENARIO: kycApprover pauses a builder KYC
      */
-    function test_PauseBuilder() public {
+    function test_PauseBuilderKyc() public {
         // GIVEN a whitelisted builder
-        //  WHEN kycApprover calls pauseBuilder
+        //  WHEN kycApprover calls pauseBuilderKYC
         vm.prank(kycApprover);
-        //   THEN Paused event is emitted
+        //   THEN KYCPaused event is emitted
         vm.expectEmit();
-        emit Paused(builder, "paused");
-        builderRegistry.pauseBuilder(builder, "paused");
+        emit KYCPaused(builder, "paused");
+        builderRegistry.pauseBuilderKYC(builder, "paused");
 
         // THEN builder is paused
-        (,,, bool _paused,,, bytes20 _reason) = builderRegistry.builderState(builder);
-        assertEq(_paused, true);
+        (,,, bool _kycPaused,,, bytes20 _reason) = builderRegistry.builderState(builder);
+        assertEq(_kycPaused, true);
         // THEN builder paused reason is "paused"
         assertEq(_reason, "paused");
     }
 
     /**
-     * SCENARIO: pause reason is 20 bytes long
+     * SCENARIO: KYC pause reason is 20 bytes long
      */
     function test_PauseReason20bytes() public {
         // GIVEN a whitelisted builder
-        //  WHEN kycApprover calls pauseBuilder
+        //  WHEN kycApprover calls pauseBuilderKYC
         vm.prank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "This is a short test");
+        builderRegistry.pauseBuilderKYC(builder, "This is a short test");
         // THEN builder is paused
-        (,,, bool _paused,,, bytes20 _reason) = builderRegistry.builderState(builder);
-        assertEq(_paused, true);
+        (,,, bool _kycPaused,,, bytes20 _reason) = builderRegistry.builderState(builder);
+        assertEq(_kycPaused, true);
         // THEN builder paused reason is "This is a short test"
         assertEq(_reason, "This is a short test");
     }
 
     /**
-     * SCENARIO: pauseBuilder again and overwritten the reason
+     * SCENARIO: pauseBuilderKYC again and overwritten the reason
      */
     function test_PauseWithAnotherReason() public {
-        // GIVEN a paused builder
-        //  AND kycApprover calls pauseBuilder
+        // GIVEN a KYC paused builder
         vm.prank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "paused");
-        (,,, bool _paused,,, bytes20 _reason) = builderRegistry.builderState(builder);
-        assertEq(_paused, true);
+        builderRegistry.pauseBuilderKYC(builder, "paused");
+        (,,, bool _kycPaused,,, bytes20 _reason) = builderRegistry.builderState(builder);
+        assertEq(_kycPaused, true);
         // THEN builder paused reason is "paused"
         assertEq(_reason, "paused");
 
         // WHEN is paused again with a different reason
         vm.prank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "pausedAgain");
+        builderRegistry.pauseBuilderKYC(builder, "pausedAgain");
         // THEN builder is still paused
-        (,,, _paused,,, _reason) = builderRegistry.builderState(builder);
-        assertEq(_paused, true);
+        (,,, _kycPaused,,, _reason) = builderRegistry.builderState(builder);
+        assertEq(_kycPaused, true);
         // THEN builder paused reason is "pausedAgain"
         assertEq(_reason, "pausedAgain");
     }
 
     /**
-     * SCENARIO: kycApprover unpauseBuilder a builder
+     * SCENARIO: kycApprover unpauses Builder KYC
      */
-    function test_UnpauseBuilder() public {
-        // GIVEN a paused builder
+    function test_UnpauseBuilderKYC() public {
+        // GIVEN a KYC paused builder
         vm.startPrank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "paused");
-        // WHEN kycApprover calls unpauseBuilder
-        //  THEN Unpaused event is emitted
+        builderRegistry.pauseBuilderKYC(builder, "paused");
+        // WHEN kycApprover calls unpauseBuilderKYC
+        //  THEN KYCResumed event is emitted
         vm.expectEmit();
-        emit Unpaused(builder);
-        builderRegistry.unpauseBuilder(builder);
+        emit KYCResumed(builder);
+        builderRegistry.unpauseBuilderKYC(builder);
 
         // THEN builder is not paused
-        (,,, bool _paused,,, bytes20 _reason) = builderRegistry.builderState(builder);
-        assertEq(_paused, false);
+        (,,, bool _kycPaused,,, bytes20 _reason) = builderRegistry.builderState(builder);
+        assertEq(_kycPaused, false);
         // THEN builder paused reason is clean
         assertEq(_reason, "");
     }
@@ -351,9 +350,9 @@ contract BuilderRegistryRootstockCollectiveTest is BaseTest {
         //  THEN tx reverts because is not revoked
         vm.expectRevert(BuilderRegistryRootstockCollective.NotRevoked.selector);
         builderRegistry.permitBuilder(1 ether);
-        // AND the builder is paused but not revoked
+        // AND the builder KYC is paused but not revoked
         vm.startPrank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "paused");
+        builderRegistry.pauseBuilderKYC(builder, "paused");
         // WHEN tries to permitBuilder
         //  THEN tx reverts because is not revoked
         vm.startPrank(builder);
@@ -596,92 +595,92 @@ contract BuilderRegistryRootstockCollectiveTest is BaseTest {
     }
 
     /**
-     * SCENARIO: KYC revoked builder can be paused and unpaused
+     * SCENARIO: KYC revoked builder can be KYC paused and unpaused
      */
-    function test_PauseKYCRevokedBuilder() public {
+    function test_PauseKycOnKycRevokedBuilder() public {
         // GIVEN a KYC revoked builder
         vm.startPrank(kycApprover);
         builderRegistry.revokeBuilderKYC(builder);
-        // AND kycApprover calls pauseBuilder
-        builderRegistry.pauseBuilder(builder, "paused");
-        (, bool _kycApproved,, bool _paused,,,) = builderRegistry.builderState(builder);
+        // AND kycApprover calls pauseBuilderKYC
+        builderRegistry.pauseBuilderKYC(builder, "paused");
+        (, bool _kycApproved,, bool _kycPaused,,,) = builderRegistry.builderState(builder);
         // THEN builder is not kycApproved
         assertEq(_kycApproved, false);
         // THEN builder is paused
-        assertEq(_paused, true);
+        assertEq(_kycPaused, true);
 
-        // AND kycApprover calls unpauseBuilder
-        builderRegistry.unpauseBuilder(builder);
-        (, _kycApproved,, _paused,,,) = builderRegistry.builderState(builder);
+        // AND kycApprover calls unpauseBuilderKYC
+        builderRegistry.unpauseBuilderKYC(builder);
+        (, _kycApproved,, _kycPaused,,,) = builderRegistry.builderState(builder);
         // THEN builder is still not kycApproved
         assertEq(_kycApproved, false);
         // THEN builder is not paused
-        assertEq(_paused, false);
+        assertEq(_kycPaused, false);
     }
 
     /**
-     * SCENARIO: revoked builder can be paused and unpaused
+     * SCENARIO: revoked builder can be kyc paused and unpaused
      */
-    function test_PauseRevokedBuilder() public {
+    function test_PauseKYCRevokedBuilder() public {
         // GIVEN a revoked builder
         vm.startPrank(builder);
         builderRegistry.revokeBuilder();
-        // AND kycApprover calls pauseBuilder
+        // AND kycApprover calls pauseBuilderKYC
         vm.startPrank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "paused");
-        (,,, bool _paused, bool _revoked,,) = builderRegistry.builderState(builder);
+        builderRegistry.pauseBuilderKYC(builder, "paused");
+        (,,, bool _kycPaused, bool _revoked,,) = builderRegistry.builderState(builder);
         // THEN builder is revoked
         assertEq(_revoked, true);
         // THEN builder is paused
-        assertEq(_paused, true);
+        assertEq(_kycPaused, true);
 
-        // AND kycApprover calls unpauseBuilder
-        builderRegistry.unpauseBuilder(builder);
-        (,,, _paused, _revoked,,) = builderRegistry.builderState(builder);
+        // AND kycApprover calls unpauseBuilderKYC
+        builderRegistry.unpauseBuilderKYC(builder);
+        (,,, _kycPaused, _revoked,,) = builderRegistry.builderState(builder);
         // THEN builder is still revoked
         assertEq(_revoked, true);
         // THEN builder is not paused
-        assertEq(_paused, false);
+        assertEq(_kycPaused, false);
     }
 
     /**
-     * SCENARIO: paused builder can be revoked and permitted
+     * SCENARIO: KYC paused builder can be revoked and permitted
      */
-    function test_RevokePausedBuilder() public {
-        // GIVEN paused builder
+    function test_RevokeKYCPausedBuilder() public {
+        // GIVEN a KYC paused builder
         vm.startPrank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "paused");
+        builderRegistry.pauseBuilderKYC(builder, "paused");
         // AND builder calls revokeBuilder
         vm.startPrank(builder);
         builderRegistry.revokeBuilder();
-        (,,, bool _paused, bool _revoked,,) = builderRegistry.builderState(builder);
+        (,,, bool _kycPaused, bool _revoked,,) = builderRegistry.builderState(builder);
         // THEN builder is paused
-        assertEq(_paused, true);
+        assertEq(_kycPaused, true);
         // THEN builder is revoked
         assertEq(_revoked, true);
 
         // AND builder calls permitBuilder
         builderRegistry.permitBuilder(0.1 ether);
-        (,,, _paused, _revoked,,) = builderRegistry.builderState(builder);
+        (,,, _kycPaused, _revoked,,) = builderRegistry.builderState(builder);
         // THEN builder is still paused
-        assertEq(_paused, true);
+        assertEq(_kycPaused, true);
         // THEN builder is not revoked
         assertEq(_revoked, false);
     }
 
     /**
-     * SCENARIO: paused builder can be KYC revoked
+     * SCENARIO: KYC paused builder can be KYC revoked
      */
     function test_KYCRevokePausedBuilder() public {
-        // GIVEN paused builder
+        // GIVEN KYC paused builder
         vm.startPrank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "paused");
+        builderRegistry.pauseBuilderKYC(builder, "paused");
 
         // AND kycApprover calls revokeBuilderKYC
         builderRegistry.revokeBuilderKYC(builder);
-        (, bool _kycApproved,, bool _paused,,,) = builderRegistry.builderState(builder);
+        (, bool _kycApproved,, bool _kycPaused,,,) = builderRegistry.builderState(builder);
         // THEN builder is paused
-        assertEq(_paused, true);
+        assertEq(_kycPaused, true);
         // THEN builder is not kyc approved
         assertEq(_kycApproved, false);
     }
@@ -781,38 +780,38 @@ contract BuilderRegistryRootstockCollectiveTest is BaseTest {
         vm.prank(governor);
         builderRegistry.dewhitelistBuilder(builder);
 
-        // AND kycApprover calls pauseBuilder
+        // AND kycApprover calls pauseBuilderKYC
         vm.startPrank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "paused");
-        (,, bool _communityApproved, bool _paused,,,) = builderRegistry.builderState(builder);
+        builderRegistry.pauseBuilderKYC(builder, "paused");
+        (,, bool _communityApproved, bool _kycPaused,,,) = builderRegistry.builderState(builder);
         // THEN builder is not whitelisted
         assertEq(_communityApproved, false);
         // THEN builder is paused
-        assertEq(_paused, true);
+        assertEq(_kycPaused, true);
 
-        // AND kycApprover calls unpauseBuilder
-        builderRegistry.unpauseBuilder(builder);
-        (,, _communityApproved, _paused,,,) = builderRegistry.builderState(builder);
+        // AND kycApprover calls unpauseBuilderKYC
+        builderRegistry.unpauseBuilderKYC(builder);
+        (,, _communityApproved, _kycPaused,,,) = builderRegistry.builderState(builder);
         // THEN builder is still not community approved
         assertEq(_communityApproved, false);
         // THEN builder is not paused
-        assertEq(_paused, false);
+        assertEq(_kycPaused, false);
     }
 
     /**
-     * SCENARIO: paused builder can be de-whitelisted
+     * SCENARIO: paused KYC builder can be de-whitelisted
      */
     function test_DewhitelistPausedBuilder() public {
-        // GIVEN paused builder
+        // GIVEN a KYC paused builder
         vm.prank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "paused");
+        builderRegistry.pauseBuilderKYC(builder, "paused");
 
         // AND governor calls dewhitelistBuilder
         vm.prank(governor);
         builderRegistry.dewhitelistBuilder(builder);
-        (,, bool _communityApproved, bool _paused,,,) = builderRegistry.builderState(builder);
+        (,, bool _communityApproved, bool _kycPaused,,,) = builderRegistry.builderState(builder);
         // THEN builder is paused
-        assertEq(_paused, true);
+        assertEq(_kycPaused, true);
         // THEN builder is not community approved
         assertEq(_communityApproved, false);
     }

--- a/test/PauseBuilderKYC.t.sol
+++ b/test/PauseBuilderKYC.t.sol
@@ -5,28 +5,28 @@ import { BaseTest } from "./BaseTest.sol";
 import { UtilsLib } from "../src/libraries/UtilsLib.sol";
 import { BuilderRegistryRootstockCollective } from "../src/builderRegistry/BuilderRegistryRootstockCollective.sol";
 
-contract PauseBuilderTest is BaseTest {
+contract PauseBuilderKYCTest is BaseTest {
     function _initialState() internal {
         // GIVEN alice and bob allocate to builder and builder2
         //  AND 100 rewardToken and 10 coinbase are distributed
         //   AND half cycle pass
         _initialDistribution();
 
-        // AND builder is paused
+        // AND builder is KYC paused
         vm.startPrank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "paused");
+        builderRegistry.pauseBuilderKYC(builder, "paused");
         vm.stopPrank();
     }
 
     /**
-     * SCENARIO: builder is paused in the middle of an cycle having allocation.
+     * SCENARIO: builder is KYC paused in the middle of an cycle having allocation.
      *  Backers claim all the rewards
      */
     function test_PausedGaugeBackersReceiveRewards() public {
         // GIVEN alice and bob allocate to builder and builder2
         //  AND 100 rewardToken and 10 coinbase are distributed
         //   AND half cycle pass
-        //    AND builder is paused
+        //    AND builder is KYC paused
         _initialState();
         // AND cycle finish
         _skipAndStartNewCycle();
@@ -51,14 +51,14 @@ contract PauseBuilderTest is BaseTest {
     }
 
     /**
-     * SCENARIO: builder is paused in the middle of an cycle having allocation.
+     * SCENARIO: builder is KYC paused in the middle of an cycle having allocation.
      *  If the builder calls claimBuilderReward the tx reverts
      */
     function test_PausedGaugeBuilderCannotReceiveRewards() public {
         // GIVEN alice and bob allocate to builder and builder2
         //  AND 100 rewardToken and 10 coinbase are distributed
         //   AND half cycle pass
-        //    AND builder is paused
+        //    AND builder is KYC paused
         _initialState();
         // AND cycle finish
         _skipAndStartNewCycle();
@@ -89,14 +89,14 @@ contract PauseBuilderTest is BaseTest {
     }
 
     /**
-     * SCENARIO: builder is paused in the middle of an cycle having allocation.
+     * SCENARIO: builder is KYC paused in the middle of an cycle having allocation.
      *  Alice can modify its allocation
      */
     function test_PausedGaugeModifyAllocation() public {
         // GIVEN alice and bob allocate to builder and builder2
         //  AND 100 rewardToken and 10 coinbase are distributed
         //   AND half cycle pass
-        //    AND builder is paused
+        //    AND builder is KYC paused
         _initialState();
 
         // WHEN alice removes allocations from paused builder
@@ -117,22 +117,22 @@ contract PauseBuilderTest is BaseTest {
     }
 
     /**
-     * SCENARIO: builder is paused in the middle of an cycle having rewards to claim,
+     * SCENARIO: builder is KYC paused in the middle of an cycle having rewards to claim,
      *  is unpaused in the same cycle and can claim them
      */
     function test_ResumeGaugeInSameCycle() public {
         // GIVEN alice and bob allocate to builder and builder2
         //  AND 100 rewardToken and 10 coinbase are distributed
         //   AND half cycle pass
-        //    AND builder is paused
+        //    AND builder is KYC paused
         _initialState();
 
         // AND 3/4 cycle pass
         _skipRemainingCycleFraction(2);
 
-        // WHEN gauge is unpaused
+        // WHEN builder's gauge is KYC unpaused
         vm.startPrank(kycApprover);
-        builderRegistry.unpauseBuilder(builder);
+        builderRegistry.unpauseBuilderKYC(builder);
 
         // WHEN builder claim rewards
         vm.startPrank(builder);
@@ -149,14 +149,14 @@ contract PauseBuilderTest is BaseTest {
     }
 
     /**
-     * SCENARIO: builder is paused in the middle of an cycle having rewards to claim,
+     * SCENARIO: builder is KYC paused in the middle of an cycle having rewards to claim,
      *  is unpaused in the next cycle and can claim the previous rewards and the new ones
      */
     function test_ResumeGaugeInNextCycle() public {
         // GIVEN alice and bob allocate to builder and builder2
         //  AND 100 rewardToken and 10 coinbase are distributed
         //   AND half cycle pass
-        //    AND builder is paused
+        //    AND builder is KYC paused
         _initialState();
 
         // AND cycle finish
@@ -164,9 +164,9 @@ contract PauseBuilderTest is BaseTest {
         // AND 100 rewardToken and 10 coinbase are distributed
         _distribute(100 ether, 10 ether);
 
-        // WHEN gauge is unpaused
+        // WHEN gauge is KYC unpaused
         vm.startPrank(kycApprover);
-        builderRegistry.unpauseBuilder(builder);
+        builderRegistry.unpauseBuilderKYC(builder);
 
         // WHEN builder claim rewards
         vm.startPrank(builder);
@@ -183,7 +183,7 @@ contract PauseBuilderTest is BaseTest {
     }
 
     /**
-     * SCENARIO: revoked builder is paused
+     * SCENARIO: revoked builder is KYC paused
      *  If the builder calls claimBuilderReward the tx reverts
      */
     function test_RevokedGaugeIsPaused() public {
@@ -194,9 +194,9 @@ contract PauseBuilderTest is BaseTest {
         // AND builder is revoked
         vm.startPrank(builder);
         builderRegistry.revokeBuilder();
-        // AND builder is paused
+        // AND builder is KYC paused
         vm.startPrank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "paused");
+        builderRegistry.pauseBuilderKYC(builder, "paused");
 
         // WHEN builder claim rewards
         vm.startPrank(builder);

--- a/test/RevokeKYC.t.sol
+++ b/test/RevokeKYC.t.sol
@@ -112,7 +112,7 @@ contract RevokeKYCTest is HaltedBuilderBehavior, ResumeBuilderBehavior {
     }
 
     /**
-     * SCENARIO: builder is paused and KYC revoked in the middle of an cycle having allocation.
+     * SCENARIO: builder is KYC paused and KYC revoked in the middle of an cycle having allocation.
      *  builder's unclaimed rewards are sent to rewardDistributor
      */
     function test_PausedBuilderIsKYCRevoked() public {
@@ -120,9 +120,9 @@ contract RevokeKYCTest is HaltedBuilderBehavior, ResumeBuilderBehavior {
         //  AND 100 rewardToken and 10 coinbase are distributed
         //   AND half cycle pass
         _initialDistribution();
-        // AND builder is paused
+        // AND builder is KYC paused
         vm.startPrank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "paused");
+        builderRegistry.pauseBuilderKYC(builder, "paused");
         // AND builder is KYC revoked
         vm.startPrank(kycApprover);
         builderRegistry.revokeBuilderKYC(builder);

--- a/test/SetBackerRewardPercentage.t.sol
+++ b/test/SetBackerRewardPercentage.t.sol
@@ -87,10 +87,10 @@ contract SetBackerRewardPercentageTest is BaseTest {
     /**
      * SCENARIO: setBackerRewardPercentage reverts if it is not operational
      */
-    function test_RevertsetBackerRewardPercentageWrongStatus() public {
+    function test_RevertSetBackerRewardPercentageWrongStatus() public {
         // GIVEN a Paused builder
         vm.startPrank(kycApprover);
-        builderRegistry.pauseBuilder(builder, "paused");
+        builderRegistry.pauseBuilderKYC(builder, "paused");
         // WHEN tries to setBackerRewardPercentage
         //  THEN tx reverts because is not operational
         vm.startPrank(builder);

--- a/test/fuzz/PauseBuilderKYC.t.sol
+++ b/test/fuzz/PauseBuilderKYC.t.sol
@@ -4,14 +4,14 @@ pragma solidity 0.8.20;
 import { BaseFuzz } from "./BaseFuzz.sol";
 import { BuilderRegistryRootstockCollective } from "../../src/builderRegistry/BuilderRegistryRootstockCollective.sol";
 
-contract PauseBuilderFuzzTest is BaseFuzz {
+contract PauseBuilderKYCFuzzTest is BaseFuzz {
     mapping(address builder_ => bool paused_) public pausedBuilders;
 
     /**
-     * SCENARIO: In a random time gauges are paused and unpaused again.
+     * SCENARIO: In a random time gauges are KYC paused and unpaused again.
      *  There is a distribution, all the gauges receive rewards
      */
-    function testFuzz_PauseBuilder(
+    function testFuzz_PauseBuilderKYC(
         uint256 buildersAmount_,
         uint256 backersAmount_,
         uint256 seed_,
@@ -74,10 +74,10 @@ contract PauseBuilderFuzzTest is BaseFuzz {
     }
 
     /**
-     * SCENARIO: In a random time gauges are paused and unpaused again. There is a distribution in the middle
+     * SCENARIO: In a random time gauges are KYC paused and unpaused again. There is a distribution in the middle
      *  There is a distribution, all the gauges receive rewards
      */
-    function testFuzz_PauseBuilderWitDistribution(
+    function testFuzz_PauseBuilderKYCWitDistribution(
         uint256 buildersAmount_,
         uint256 backersAmount_,
         uint256 seed_,
@@ -152,7 +152,7 @@ contract PauseBuilderFuzzTest is BaseFuzz {
             // 70% chance to pause
             if (_random % 10 > 2) {
                 vm.prank(kycApprover);
-                builderRegistry.pauseBuilder(builders[i], "pause");
+                builderRegistry.pauseBuilderKYC(builders[i], "pause");
                 pausedBuilders[builders[i]] = true;
             }
         }
@@ -164,7 +164,7 @@ contract PauseBuilderFuzzTest is BaseFuzz {
             // 70% chance to unpause
             if (pausedBuilders[builders[i]] && _random % 10 > 2) {
                 vm.prank(kycApprover);
-                builderRegistry.unpauseBuilder(builders[i]);
+                builderRegistry.unpauseBuilderKYC(builders[i]);
                 pausedBuilders[builders[i]] = false;
             }
         }


### PR DESCRIPTION
## What

- Renaming PR divided for each related change. This PR contains the builder renaming change from `paused and unpaused` to `kyc paused and resumed`

## Refs

- [JIRA](https://rsklabs.atlassian.net/jira/software/projects/TOK/boards/267?assignee=712020%3A42dabdd3-0b32-4060-be21-62cfd46a1751&selectedIssue=TOK-535)