### PR TITLE
TOK-698/halt-resume-gauges

### DIFF
--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -603,9 +603,15 @@ contract BackersManagerRootstockCollective is
      * produce a miscalculation of rewards
      * @param gauge_ gauge contract to be halted
      */
-    function haltGaugeShares(GaugeRootstockCollective gauge_) external onlyBuilderRegistry notInDistributionPeriod {
+    function haltGaugeShares(GaugeRootstockCollective gauge_)
+        external
+        onlyBuilderRegistry
+        notInDistributionPeriod
+        returns (uint256)
+    {
         // allocations are not considered for the reward's distribution
         totalPotentialReward -= gauge_.rewardShares();
+        return _periodFinish;
     }
 
     /**

--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -602,6 +602,7 @@ contract BackersManagerRootstockCollective is
      * @dev reverts if it is executed in distribution period because changing the totalPotentialReward
      * produce a miscalculation of rewards
      * @param gauge_ gauge contract to be halted
+     * @return periodFinish_ timestamp indicating the end of the current rewards period
      */
     function haltGaugeShares(GaugeRootstockCollective gauge_)
         external

--- a/src/builderRegistry/BuilderRegistryRootstockCollective.sol
+++ b/src/builderRegistry/BuilderRegistryRootstockCollective.sol
@@ -613,9 +613,7 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
         if (!isGaugeHalted(address(gauge_))) {
             _haltedGauges.add(address(gauge_));
             _gauges.remove(address(gauge_));
-            BackersManagerRootstockCollective _backersManager = backersManager;
-            _backersManager.haltGaugeShares(gauge_);
-            haltedGaugeLastPeriodFinish[gauge_] = _backersManager.periodFinish();
+            haltedGaugeLastPeriodFinish[gauge_] = backersManager.haltGaugeShares(gauge_);
         }
     }
 

--- a/src/builderRegistry/BuilderRegistryRootstockCollective.sol
+++ b/src/builderRegistry/BuilderRegistryRootstockCollective.sol
@@ -615,7 +615,7 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
             _gauges.remove(address(gauge_));
             BackersManagerRootstockCollective _backersManager = backersManager;
             _backersManager.haltGaugeShares(gauge_);
-            _setHaltedGaugeLastPeriodFinish(gauge_, _backersManager.periodFinish());
+            haltedGaugeLastPeriodFinish[gauge_] = _backersManager.periodFinish();
         }
     }
 
@@ -629,7 +629,7 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
             _gauges.add(address(gauge_));
             _haltedGauges.remove(address(gauge_));
             backersManager.resumeGaugeShares(gauge_, haltedGaugeLastPeriodFinish[gauge_]);
-            _setHaltedGaugeLastPeriodFinish(gauge_, 0);
+            haltedGaugeLastPeriodFinish[gauge_] = 0;
         }
     }
 
@@ -687,10 +687,6 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
         backersManager.rewardTokenApprove(address(gauge_), type(uint256).max);
 
         emit CommunityApproved(builder_);
-    }
-
-    function _setHaltedGaugeLastPeriodFinish(GaugeRootstockCollective gauge_, uint256 periodFinish_) internal {
-        haltedGaugeLastPeriodFinish[gauge_] = periodFinish_;
     }
 
     /**


### PR DESCRIPTION
## What

- Reduce the amount of external calls in the resume and halt gauges methods

## Why

- Going back and forth make the code complex
- Reduce gas cost

## Gas comparison
- Old
![Screenshot 2025-04-23 at 10 23 14 AM](https://github.com/user-attachments/assets/0c2154bc-65bd-4de4-ad88-ef0a5c3c4e07)


- New
![Screenshot 2025-04-23 at 10 20 13 AM](https://github.com/user-attachments/assets/4dd4bd2d-0bad-40b0-8a61-1641cf2b25d4)

## Refs

- [TOK-698](https://rsklabs.atlassian.net/browse/TOK-698)
