### PR TITLE
TOK-625: claim backers reward method per token

### DIFF
--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -327,17 +327,30 @@ contract BackersManagerRootstockCollective is
     /**
      * @notice claims backer rewards from a batch of gauges
      * @param gauges_ array of gauges to claim
-     * @param rewardToken_ address of the token rewarded
-     *  address(uint160(uint256(keccak256("COINBASE_ADDRESS")))) is used for coinbase address
      */
-    function claimBackerRewards(address rewardToken_, GaugeRootstockCollective[] memory gauges_) external {
+    function claimBackerRIFReward(GaugeRootstockCollective[] memory gauges_) external {
         uint256 _length = gauges_.length;
         BuilderRegistryRootstockCollective _builderRegistry = builderRegistry;
         for (uint256 i = 0; i < _length; i = UtilsLib._uncheckedInc(i)) {
             if (_builderRegistry.gaugeToBuilder(gauges_[i]) == address(0)) {
                 revert BuilderRegistryRootstockCollective.GaugeDoesNotExist();
             }
-            gauges_[i].claimBackerReward(rewardToken_, msg.sender);
+            gauges_[i].claimBackerRIFReward(msg.sender);
+        }
+    }
+
+    /**
+     * @notice claims backer rewards from a batch of gauges
+     * @param gauges_ array of gauges to claim
+     */
+    function claimBackerRBTCReward(GaugeRootstockCollective[] memory gauges_) external {
+        uint256 _length = gauges_.length;
+        BuilderRegistryRootstockCollective _builderRegistry = builderRegistry;
+        for (uint256 i = 0; i < _length; i = UtilsLib._uncheckedInc(i)) {
+            if (_builderRegistry.gaugeToBuilder(gauges_[i]) == address(0)) {
+                revert BuilderRegistryRootstockCollective.GaugeDoesNotExist();
+            }
+            gauges_[i].claimBackerRBTCReward(msg.sender);
         }
     }
 

--- a/src/gauge/GaugeRootstockCollective.sol
+++ b/src/gauge/GaugeRootstockCollective.sol
@@ -238,36 +238,22 @@ contract GaugeRootstockCollective is ReentrancyGuardUpgradeable {
         return _earned(rewardToken_, backer_, backersManager.periodFinish());
     }
 
+    function claimBackerRIFReward(address backer_) public {
+        _claimBackerReward(rewardToken, backer_);
+    }
+
+    function claimBackerRBTCReward(address backer_) public {
+        _claimBackerReward(UtilsLib._COINBASE_ADDRESS, backer_);
+    }
+
     /**
      * @notice claim rewards for a `backer_` address
      * @dev reverts if is not called by the `backer_` or the backersManager
      * @param backer_ address who receives the rewards
      */
     function claimBackerReward(address backer_) external {
-        claimBackerReward(rewardToken, backer_);
-        claimBackerReward(UtilsLib._COINBASE_ADDRESS, backer_);
-    }
-
-    /**
-     * @notice claim rewards for a `backer_` address
-     * @dev reverts if is not called by the `backer_` or the backersManager
-     * @param rewardToken_ address of the token rewarded
-     *  address(uint160(uint256(keccak256("COINBASE_ADDRESS")))) is used for coinbase address
-     * @param backer_ address who receives the rewards
-     */
-    function claimBackerReward(address rewardToken_, address backer_) public {
-        if (msg.sender != backer_ && msg.sender != address(backersManager)) revert NotAuthorized();
-
-        RewardData storage _rewardData = rewardData[rewardToken_];
-
-        _updateRewards(rewardToken_, backer_, backersManager.periodFinish());
-
-        uint256 _reward = _rewardData.rewards[backer_];
-        if (_reward > 0) {
-            _rewardData.rewards[backer_] = 0;
-            _transferRewardToken(rewardToken_, backer_, _reward);
-            emit BackerRewardsClaimed(rewardToken_, backer_, _reward);
-        }
+        claimBackerRIFReward(backer_);
+        claimBackerRBTCReward(backer_);
     }
 
     /**
@@ -467,6 +453,28 @@ contract GaugeRootstockCollective is ReentrancyGuardUpgradeable {
     // -----------------------------
     // ---- Internal Functions -----
     // -----------------------------
+
+    /**
+     * @notice claim rewards for a `backer_` address
+     * @dev reverts if is not called by the `backer_` or the backersManager
+     * @param rewardToken_ address of the token rewarded
+     *  address(uint160(uint256(keccak256("COINBASE_ADDRESS")))) is used for coinbase address
+     * @param backer_ address who receives the rewards
+     */
+    function _claimBackerReward(address rewardToken_, address backer_) internal {
+        if (msg.sender != backer_ && msg.sender != address(backersManager)) revert NotAuthorized();
+
+        RewardData storage _rewardData = rewardData[rewardToken_];
+
+        _updateRewards(rewardToken_, backer_, backersManager.periodFinish());
+
+        uint256 _reward = _rewardData.rewards[backer_];
+        if (_reward > 0) {
+            _rewardData.rewards[backer_] = 0;
+            _transferRewardToken(rewardToken_, backer_, _reward);
+            emit BackerRewardsClaimed(rewardToken_, backer_, _reward);
+        }
+    }
 
     /**
      * @notice gets the last time the reward is applicable, now or when the cycle finished

--- a/test/BackersManagerRootstockCollective.t.sol
+++ b/test/BackersManagerRootstockCollective.t.sol
@@ -57,17 +57,17 @@ contract BackersManagerRootstockCollectiveTest is BaseTest {
         vm.expectRevert(BuilderRegistryRootstockCollective.GaugeDoesNotExist.selector);
         backersManager.claimBackerRewards(gaugesArray);
 
-        //  WHEN alice calls claimBackerRewards using the wrong gauge
+        //  WHEN alice calls claimBackerRIFReward using the wrong gauge
         //   THEN tx reverts because GaugeDoesNotExist
         vm.prank(alice);
         vm.expectRevert(BuilderRegistryRootstockCollective.GaugeDoesNotExist.selector);
-        backersManager.claimBackerRewards(address(rewardToken), gaugesArray);
+        backersManager.claimBackerRIFReward(gaugesArray);
 
-        //  WHEN alice calls claimBackerRewards using the wrong gauge
+        //  WHEN alice calls claimBackerRBTCReward using the wrong gauge
         //   THEN tx reverts because GaugeDoesNotExist
         vm.prank(alice);
         vm.expectRevert(BuilderRegistryRootstockCollective.GaugeDoesNotExist.selector);
-        backersManager.claimBackerRewards(UtilsLib._COINBASE_ADDRESS, gaugesArray);
+        backersManager.claimBackerRBTCReward(gaugesArray);
     }
 
     /**
@@ -1241,7 +1241,7 @@ contract BackersManagerRootstockCollectiveTest is BaseTest {
 
         // WHEN alice claim rewards
         vm.prank(alice);
-        backersManager.claimBackerRewards(address(rewardToken), gaugesArray);
+        backersManager.claimBackerRIFReward(gaugesArray);
 
         // THEN alice rewardToken balance is 50% of the distributed amount
         assertEq(rewardToken.balanceOf(alice), 49_999_999_999_999_999_992);
@@ -1276,7 +1276,7 @@ contract BackersManagerRootstockCollectiveTest is BaseTest {
 
         // WHEN alice claim rewards
         vm.prank(alice);
-        backersManager.claimBackerRewards(UtilsLib._COINBASE_ADDRESS, gaugesArray);
+        backersManager.claimBackerRBTCReward(gaugesArray);
 
         // THEN alice coinbase balance is 50% of the distributed amount
         assertEq(alice.balance, 24_999_999_999_999_999_992);

--- a/test/GaugeRootstockCollective.t.sol
+++ b/test/GaugeRootstockCollective.t.sol
@@ -63,10 +63,15 @@ contract GaugeRootstockCollectiveTest is BaseTest {
     function test_NotAuthorized() public {
         // GIVEN a backer alice
         vm.startPrank(alice);
-        // WHEN alice calls claimBackerReward using bob address
+        // WHEN alice calls claimBackerRIFReward using bob address
         //  THEN tx reverts because caller is not authorized
         vm.expectRevert(GaugeRootstockCollective.NotAuthorized.selector);
-        gauge.claimBackerReward(address(rewardToken), bob);
+        gauge.claimBackerRIFReward(bob);
+
+        // WHEN alice calls claimBackerRBTCReward using bob address
+        //  THEN tx reverts because caller is not authorized
+        vm.expectRevert(GaugeRootstockCollective.NotAuthorized.selector);
+        gauge.claimBackerRIFReward(bob);
 
         // WHEN alice calls claimBackerReward using bob address
         //  THEN tx reverts because caller is not authorized
@@ -1633,13 +1638,13 @@ contract GaugeRootstockCollectiveTest is BaseTest {
 
         // WHEN alice claims rewards
         vm.prank(alice);
-        gauge.claimBackerReward(address(rewardToken), alice);
+        gauge.claimBackerRIFReward(alice);
         // THEN alice rewardToken balance is 16.666666666666666666 = 1 * 16.666666666666666666
         assertEq(rewardToken.balanceOf(alice), 16_666_666_666_666_666_666);
 
         // WHEN bob claims rewards
         vm.prank(bob);
-        gauge.claimBackerReward(address(rewardToken), bob);
+        gauge.claimBackerRIFReward(bob);
         // THEN bob rewardToken balance is 83.333333333333333330 = 5 * 16.666666666666666666
         assertEq(rewardToken.balanceOf(bob), 83_333_333_333_333_333_330);
     }
@@ -1669,13 +1674,13 @@ contract GaugeRootstockCollectiveTest is BaseTest {
 
         // WHEN alice claims rewards
         vm.prank(alice);
-        gauge.claimBackerReward(UtilsLib._COINBASE_ADDRESS, alice);
+        gauge.claimBackerRBTCReward(alice);
         // THEN alice coinbase balance is 16.666666666666666666 = 1 * 16.666666666666666666
         assertEq(alice.balance, 16_666_666_666_666_666_666);
 
         // WHEN bob claims rewards
         vm.prank(bob);
-        gauge.claimBackerReward(UtilsLib._COINBASE_ADDRESS, bob);
+        gauge.claimBackerRBTCReward(bob);
         // THEN bob coinbase balance is 83.333333333333333330 = 5 * 16.666666666666666666
         assertEq(bob.balance, 83_333_333_333_333_333_330);
     }


### PR DESCRIPTION
## What

### In `Gauge` contract:

- makes `claimBackerReward(address,address)` internal
- adds public `claimBackerRIFReward(address)`
- and public `claimBackerRBTCReward(address)`

### In `BackersManager` contract

- removes `claimBackerRewards(address,addess)`
- adds public `claimBackerRIFReward(address)`
- adds public `claimBackerRBTCReward(address)`

## Testing

- regression on claiming backers rewards

## Refs

- [TOK-625](https://rsklabs.atlassian.net/browse/TOK-625)
