### PR TITLE
TOK-699_reduce-external-calls-in-BackersManager.allocate

### DIFF
--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -436,13 +436,13 @@ contract BackersManagerRootstockCollective is
         internal
         returns (uint256 newBackerTotalAllocation_, uint256 newTotalPotentialReward_)
     {
-        builderRegistry_.requireInitializedBuilder(gauge_);
+        bool _isHalted = builderRegistry_.isGaugeHaltedValidated(gauge_);
 
         (uint256 _allocationDeviation, uint256 _rewardSharesDeviation, bool _isNegative) =
             gauge_.allocate(msg.sender, allocation_, timeUntilNextCycle_);
 
         // halted gauges are not taken into account for the rewards; newTotalPotentialReward_ == totalPotentialReward_
-        if (builderRegistry_.isGaugeHalted(address(gauge_))) {
+        if (_isHalted) {
             if (!_isNegative) {
                 revert PositiveAllocationOnHaltedGauge();
             }

--- a/src/backersManager/BackersManagerRootstockCollective.sol
+++ b/src/backersManager/BackersManagerRootstockCollective.sol
@@ -436,7 +436,7 @@ contract BackersManagerRootstockCollective is
         internal
         returns (uint256 newBackerTotalAllocation_, uint256 newTotalPotentialReward_)
     {
-        bool _isHalted = builderRegistry_.isGaugeHaltedValidated(gauge_);
+        bool _isHalted = builderRegistry_.validateGaugeHalted(gauge_);
 
         (uint256 _allocationDeviation, uint256 _rewardSharesDeviation, bool _isNegative) =
             gauge_.allocate(msg.sender, allocation_, timeUntilNextCycle_);

--- a/src/builderRegistry/BuilderRegistryRootstockCollective.sol
+++ b/src/builderRegistry/BuilderRegistryRootstockCollective.sol
@@ -471,6 +471,18 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
     }
 
     /**
+     * @notice Validates if a gauge is halted and can accept allocations
+     * @dev This function first checks if the gauge is initialized and then checks if it is halted.
+     *      Halted gauges can only have negative allocations (withdrawals) and are not considered for rewards.
+     * @param gauge_ The gauge contract to check
+     * @return bool True if the gauge is halted, false otherwise
+     */
+    function isGaugeHaltedValidated(GaugeRootstockCollective gauge_) external view returns (bool) {
+        requireInitializedBuilder(gauge_);
+        return isGaugeHalted(address(gauge_));
+    }
+
+    /**
      * @notice return true if builder is operational
      *  kycApproved == true &&
      *  communityApproved == true &&
@@ -599,7 +611,7 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
      * @dev reverts if it is not called by the backers manager
      * @param gauge_ The gauge to validate.
      */
-    function requireInitializedBuilder(GaugeRootstockCollective gauge_) external view {
+    function requireInitializedBuilder(GaugeRootstockCollective gauge_) public view {
         address _builder = gaugeToBuilder[gauge_];
         if (_builder == address(0)) revert GaugeDoesNotExist();
         if (!builderState[_builder].initialized) revert BuilderNotInitialized();

--- a/src/builderRegistry/BuilderRegistryRootstockCollective.sol
+++ b/src/builderRegistry/BuilderRegistryRootstockCollective.sol
@@ -477,7 +477,7 @@ contract BuilderRegistryRootstockCollective is UpgradeableRootstockCollective {
      * @param gauge_ The gauge contract to check
      * @return bool True if the gauge is halted, false otherwise
      */
-    function isGaugeHaltedValidated(GaugeRootstockCollective gauge_) external view returns (bool) {
+    function validateGaugeHalted(GaugeRootstockCollective gauge_) external view returns (bool) {
         requireInitializedBuilder(gauge_);
         return isGaugeHalted(address(gauge_));
     }


### PR DESCRIPTION
## What

- reduce the number of external calls made from the `BackersManager` to the `BuilderRegistry` by creating a single function for that role 

## Why

- to reduce gas cost

## Testing

- `forge test`
